### PR TITLE
Refactor reader

### DIFF
--- a/traffic_prophet/countmatch/reader.py
+++ b/traffic_prophet/countmatch/reader.py
@@ -21,7 +21,7 @@ class Count:
         self.data = data
 
 
-class AnnualCount(Count):
+class RawAnnualCount(Count):
     """Storage for total and average daily traffic."""
 
     def __init__(self, count_id, centreline_id, direction, year,
@@ -29,6 +29,132 @@ class AnnualCount(Count):
         self.year = int(year)
         super().__init__(count_id, centreline_id, direction, data,
                          is_permanent=is_permanent)
+
+    @classmethod
+    def from_raw_data(cls, rd):
+        """Processes input data.
+
+        Parameters
+        ----------
+        rd : dict
+            Raw data, with entries for 'centreline_id', 'direction',
+            'year' and 'data'.  The first three are integers, while 'data'
+            is a `pandas.DataFrame` with 'Count' column and either 'Timestamp'
+            or 'Date' column.
+        """
+        if 'Date' not in rd['data'].columns:
+            raise ValueError("raw input data missing 'Date' column.")
+
+        # Save to a new object.
+        return cls(rd['centreline_id'] * rd['direction'], rd['centreline_id'],
+                   rd['direction'], rd['year'], rd['data'])
+
+
+class ReaderBase:
+
+    def __init__(self, source):
+        # Store permanent and temporary stations.
+        self.counts = None
+        self.source = source
+
+    def read(self):
+        """Read source data into a dictionary of counts."""
+        # Holds processed counts.
+        counts = {}
+        # Read counts from source.
+        self.read_source(counts)
+        # Combine counts at the same location and different years.
+        self.unify_counts(counts)
+        self.counts = counts
+
+    def read_source(self, counts):
+        raise NotImplementedError
+
+    @staticmethod
+    def reset_daily_count_index(daily_count):
+        """In-place reset of `daily_count` index to be the day of year."""
+        daily_count.set_index(
+            pd.Index(daily_count['Date'].dt.dayofyear, name='Day of Year'),
+            inplace=True)
+
+    @staticmethod
+    def has_enough_data(data):
+        """Checks if there is enough data to be a usable count."""
+        return data.shape[0] >= cfg.cm['min_stn_count']
+
+    @staticmethod
+    def append_counts(current_counts, counts):
+        for c in current_counts:
+            if c.count_id in counts.keys():
+                counts[c.count_id].append(c)
+            else:
+                counts[c.count_id] = [c, ]
+
+    @staticmethod
+    def unify_counts(counts):
+        """Unify count objects across years.
+
+        Works **in place**, and replaces the index of each table with a
+        MultiIndex.
+        """
+        for cid in counts.keys():
+            for item in counts[cid]:
+                _ctable = item.data
+                _ctable.index = pd.MultiIndex.from_product(
+                    [[item.year, ], _ctable.index],
+                    names=['Year', _ctable.index.name])
+            unified_data = pd.concat([c.data for c in counts[cid]])
+            counts[cid] = Count(counts[cid][0].count_id,
+                                counts[cid][0].centreline_id,
+                                counts[cid][0].direction,
+                                unified_data, is_permanent=False)
+
+
+class ReaderZip(ReaderBase):
+
+    def __init__(self, source):
+        if type(source) == str:
+            source = glob.glob(source)
+        elif type(source) == dict:
+            source = [source[k] for k in sorted(source.keys())]
+        source = sorted(source)
+
+        super().__init__(source)
+
+    def read_source(self, counts):
+        """Read zip file contents into RawAnnualCount objects."""
+        # Cycle through all zip files.
+        for zf in self.source:
+            # Check if the file's actually a zip.
+            if not zipfile.is_zipfile(zf):
+                raise IOError('{0} is not a zip file.'.format(zf))
+
+            current_counts = [
+                RawAnnualCount.from_raw_data(
+                    self.preprocess_count_data(c))
+                for c in self.get_zipreader(zf)]
+
+            # Append counts to processed count dicts.
+            self.append_counts(current_counts, counts)
+
+    def preprocess_count_data(self, rd):
+        """Calculates total daily traffic from raw count data."""
+        # Copy file and round timestamps to the nearest 15 minutes.
+        crd = self.regularize_timeseries(rd)
+        # Get daily total count values.
+        crdg = crd.groupby('Date')
+        # Get the number of bins per day and drop days with fewer than the
+        # minimum allowed number of counts.
+        valids = crdg['Count'].count() >= cfg.cm['min_counts_in_day']
+        # Calculate daily counts.
+        daily_count = pd.DataFrame({
+            'Daily Count': 96. * crdg['Count'].mean()[valids]})
+        daily_count.reset_index(inplace=True)
+        daily_count['Date'] = pd.to_datetime(daily_count['Date'])
+        # Reset index to day of year.
+        self.reset_daily_count_index(daily_count)
+        rd['data'] = daily_count
+        return rd
 
     @staticmethod
     def regularize_timeseries(rd):
@@ -73,204 +199,10 @@ class AnnualCount(Count):
 
         return crd
 
-    @staticmethod
-    def process_15min_count_data(crd):
-        """Calculates total daily traffic from raw count data."""
-        crdg = crd.groupby('Date')
-        # Get the number of bins per day and drop days with fewer than the
-        # minimum allowed number of counts.
-        valids = crdg['Count'].count() >= cfg.cm['min_counts_in_day']
-        # Calculate daily counts.
-        daily_count = pd.DataFrame({
-            'Daily Count': 96. * crdg['Count'].mean()[valids]})
-        daily_count.reset_index(inplace=True)
-        daily_count['Date'] = pd.to_datetime(daily_count['Date'])
-        return daily_count
-
-    @staticmethod
-    def reset_daily_count_index(daily_count):
-        """In-place reset of `daily_count` index to be the day of year."""
-        daily_count.set_index(
-            pd.Index(daily_count['Date'].dt.dayofyear, name='Day of Year'),
-            inplace=True)
-
-    @staticmethod
-    def is_permanent_count(rd):
-        """Check if a count is permanent.
-
-        Checks if count is a permanent traffic count.  Currently permanent
-        count needs to have all 12 months and a sufficient number of total
-        days represented, not be from HW401 and not be excluded by the user
-        in the config file.
-
-        Parameters
-        ----------
-        rd : dict
-            Raw data, with entries for 'centreline_id', 'direction',
-            'year' and 'data'.  The first three are integers, while 'data'
-            is a `pandas.DataFrame` with 'Timestamp' and 'Count' columns.
-
-        """
-        if 'Timestamp' in rd['data'].columns:
-            n_available_months = (rd['data']['Timestamp']
-                                  .dt.month.unique().shape[0])
-            permanent_stn_days = rd['data'].shape[0] // 96
-        elif 'Date' in rd['data'].columns:
-            n_available_months = (rd['data']['Date']
-                                  .dt.month.unique().shape[0])
-            permanent_stn_days = rd['data'].shape[0]
-        else:
-            raise ValueError("raw input data missing "
-                             "'Timestamp' or 'Date' column.")
-
-        if (n_available_months == 12 and
-                (permanent_stn_days >= cfg.cm['min_permanent_stn_days'])):
-            excluded_pos_files = (
-                rd['direction'] == 1 and
-                rd['centreline_id'] in cfg.cm['exclude_ptc_pos'])
-            excluded_neg_files = (
-                rd['direction'] == -1 and
-                rd['centreline_id'] in cfg.cm['exclude_ptc_neg'])
-            if (not excluded_pos_files and not excluded_neg_files and
-                    're' not in rd['filename']):
-                return True
-
-        return False
-
-    @staticmethod
-    def process_permanent_count_data(dc):
-        """Derives AADT, DoMADT and DoM factor values for permanent counts.
-
-        Notes
-        -----
-        Averaging methods are more conservative than `STTC_estimate3.m` - only
-        days with complete data are included in the MADT and DoMADT estimates.
-
-        Parameters
-        ----------
-        dc : pandas.DataFrame
-           DataFrame containing daily counts.
-
-        """
-        # Ensure dc remains unchanged by the method.
-        cdc = dc.copy()
-        cdc['Month'] = cdc['Date'].dt.month
-        cdc['Day of Week'] = cdc['Date'].dt.dayofweek
-
-        # Calculate MADT.
-        cdc_m = cdc.groupby('Month')
-        madt = pd.DataFrame({
-            'MADT': cdc_m['Daily Count'].mean(),
-            'Days in Month': cdc_m['Date'].min().dt.days_in_month}
-        )
-
-        # Calculate day-of-week of month ADT.
-        cdc_dom = cdc.groupby(['Month', 'Day of Week'])
-        domadt = cdc_dom['Daily Count'].mean().unstack()
-        # Determine DoM conversion factor.  (Uses a numpy broadcasting trick.)
-        dom_factor = madt['MADT'].values[:, np.newaxis] / domadt
-
-        # Weighted average for AADT.
-        aadt = np.average(madt['MADT'], weights=madt['Days in Month'])
-
-        return {'Daily Count': dc, 'MADT': madt, 'DoMADT': domadt,
-                'DoM Factor': dom_factor, 'AADT': aadt}
-
-    @classmethod
-    def from_raw_data(cls, rd):
-        """Processes input data.
-
-        Parameters
-        ----------
-        rd : dict
-            Raw data, with entries for 'centreline_id', 'direction',
-            'year' and 'data'.  The first three are integers, while 'data'
-            is a `pandas.DataFrame` with 'Count' column and either 'Timestamp'
-            or 'Date' column.
-        """
-        # If we're reading from raw zip files.
-        if 'Timestamp' in rd['data'].columns:
-            # Copy file and round timestamps to the nearest 15 minutes.
-            crd = cls.regularize_timeseries(rd)
-            # Get daily total count values.
-            daily_count = cls.process_15min_count_data(crd)
-        # If we're instead reading from Postgres.
-        elif 'Date' in rd['data'].columns:
-            daily_count = rd['data'].copy()
-        else:
-            raise ValueError("raw input data missing "
-                             "'Timestamp' or 'Date' column.")
-
-        # Reset daily_count index, common to both zip files and Postgres.
-        cls.reset_daily_count_index(daily_count)
-
-        # If count is permanent, also get MADT, AADT, DoMADT and DoM factors.
-        if cls.is_permanent_count(rd):
-            # Save to a new object.
-            ptc_data = cls.process_permanent_count_data(daily_count)
-            return cls(rd['centreline_id'] * rd['direction'],
-                       rd['centreline_id'], rd['direction'], rd['year'],
-                       ptc_data, is_permanent=True)
-
-        # Save to a new object.
-        return cls(rd['centreline_id'] * rd['direction'], rd['centreline_id'],
-                   rd['direction'], rd['year'], daily_count)
-
-
-class Reader:
-
-    def __init__(self, source):
-        # Store permanent and temporary stations.
-        self.ptcs = None
-        self.sttcs = None
-
-        # Handle read source.
-        if isinstance(source, conn.Connection):
-            # TO DO: figure out psycopg2 connection.
-            self.sourcetype = 'SQL'
-            self._reader = self.read_sql
-        else:
-            self.sourcetype = 'Zip'
-            self._reader = self.read_zip
-            if type(source) == str:
-                source = glob.glob(source)
-            elif type(source) == dict:
-                source = [source[k] for k in sorted(source.keys())]
-            source = sorted(source)
-
-        self.source = source
-
-    def read(self):
-        """Read source data into dictionaries of counts."""
-        self._reader()
-
-    def read_zip(self):
-        """Read zip file contents into AnnualCount objects."""
-        # ptcs and sttcs hold arrays of processed counts.
-        ptcs = {}
-        sttcs = {}
-
-        # Cycle through all zip files.
-        for zf in self.source:
-            # Check if the file's actually a zip.
-            if not zipfile.is_zipfile(zf):
-                raise IOError('{0} is not a zip file.'.format(zf))
-
-            current_counts = [AnnualCount.from_raw_data(c)
-                              for c in self.get_zipreader(zf)]
-
-            # Append counts to processed count dicts.
-            self.append_counts(current_counts, ptcs, sttcs)
-
-        self.check_processed_count_integrity(ptcs, sttcs)
-        self.unify_counts(ptcs, sttcs)
-        self.ptcs = ptcs
-        self.sttcs = sttcs
-
     def get_zipreader(self, zipname):
         """Create an iterator over 15-minute count zip file.
 
-        Assumes Arman's TEPs-I format: data is tab-delimited, and centreline
+        Assumes TEPs-I format: data is tab-delimited, and centreline
         ID is 2nd column and direction is 3rd column.
         """
 
@@ -300,24 +232,27 @@ class Reader:
                            'data': data,
                            'year': data.at[0, 'Timestamp'].year}
 
-    def read_sql(self):
-        """Read PostgreSQL table contents into AnnualCount objects."""
-        # ptcs and sttcs hold arrays of processed counts.
-        ptcs = {}
-        sttcs = {}
 
+class ReaderPostgres(ReaderBase):
+
+    def read_source(self, counts):
+        """Read PostgreSQL table contents into RawAnnualCount objects."""
         # Cycle through all relevant years.
         for year in range(cfg.cm['min_year'], cfg.cm['max_year'] + 1):
-            current_counts = [AnnualCount.from_raw_data(c)
-                              for c in self.get_sqlreader(year)]
+            current_counts = [
+                RawAnnualCount.from_raw_data(
+                    self.preprocess_count_data(c))
+                for c in self.get_sqlreader(year)]
 
             # Append counts to processed count dicts.
-            self.append_counts(current_counts, ptcs, sttcs)
+            self.append_counts(current_counts, counts)
 
-        self.check_processed_count_integrity(ptcs, sttcs)
-        self.unify_counts(ptcs, sttcs)
-        self.ptcs = ptcs
-        self.sttcs = sttcs
+    def preprocess_count_data(self, rd):
+        """Minor preprocessing of raw count data."""
+        daily_count = rd['data'].copy()
+        self.reset_daily_count_index(daily_count)
+        rd['data'] = daily_count
+        return rd
 
     def get_sqlreader(self, year):
         with self.source.connect() as db_con:
@@ -346,77 +281,12 @@ class Reader:
                        'data': data,
                        'year': year}
 
-    @staticmethod
-    def has_enough_data(data):
-        """Checks if there is enough data to be a usable short count count."""
-        return data.shape[0] >= cfg.cm['min_stn_count']
 
-    @staticmethod
-    def append_counts(current_counts, ptcs, sttcs):
-        for c in current_counts:
-            _appendto = ptcs if c.is_permanent else sttcs
-            if c.count_id in _appendto.keys():
-                _appendto[c.count_id].append(c)
-            else:
-                _appendto[c.count_id] = [c, ]
+def read(source):
 
-    @staticmethod
-    def check_processed_count_integrity(ptcs, sttcs):
-        if not len(sttcs) + len(ptcs):
-            raise ValueError(
-                "no count file has more than cfg.cm['min_stn_count'] == {0}."
-                "  Check input data.".format(cfg.cm['min_stn_count']))
-        elif not len(ptcs):
-            warnings.warn(
-                "no permanent counts read!  Check 'min_permanent_stn_days', "
-                "'exclude_ptc_pos' and 'exclude_ptc_neg' settings, and "
-                "confirm that counts covering all 12 months of a year exist.")
-        elif not len(sttcs):
-            warnings.warn("file only contains permanent counts!")
+    rdr = (ReaderPostgres(source) if isinstance(source, conn.Connection)
+           else ReaderZip(source))
 
-    @staticmethod
-    def unify_counts(ptcs, sttcs):
-        """Unify count objects across years.
+    rdr.read()
 
-        For each centreline ID in `ptcs`, create data tables for each
-        value and all years.  Works **in place**, and replaces the index of
-        each table with a MultiIndex.
-        """
-        # For permanent counts, perform in-place reindexing, then unify each
-        # type of data into a dict.
-        for cid in ptcs.keys():
-            for item in ptcs[cid]:
-                # Create multi-indexes for data in each count object.  This
-                # action is NOT idempotent, but I prefer this to making copies
-                # of tables.
-                for subkey in ['MADT', 'DoMADT', 'DoM Factor', 'Daily Count']:
-                    _ctable = item.data[subkey]
-                    _ctable.index = pd.MultiIndex.from_product(
-                        [[item.year, ], _ctable.index],
-                        names=['Year', _ctable.index.name])
-            unified_data = {
-                'MADT': pd.concat([c.data['MADT'] for c in ptcs[cid]]),
-                'DoMADT': pd.concat([c.data['DoMADT'] for c in ptcs[cid]]),
-                'DoM Factor': pd.concat(
-                    [c.data['DoM Factor'] for c in ptcs[cid]]),
-                'Daily Count': pd.concat(
-                    [c.data['Daily Count'] for c in ptcs[cid]]),
-                'AADT': pd.DataFrame(
-                    {'AADT': [c.data['AADT'] for c in ptcs[cid]]},
-                    index=pd.Index([c.year for c in ptcs[cid]], name='Year'))}
-            # Replace list of multipe counts with a single Count object.
-            ptcs[cid] = Count(ptcs[cid][0].count_id,
-                              ptcs[cid][0].centreline_id,
-                              ptcs[cid][0].direction,
-                              unified_data, is_permanent=True)
-        for cid in sttcs.keys():
-            for item in sttcs[cid]:
-                _ctable = item.data
-                _ctable.index = pd.MultiIndex.from_product(
-                    [[item.year, ], _ctable.index],
-                    names=['Year', _ctable.index.name])
-            unified_data = pd.concat([c.data for c in sttcs[cid]])
-            sttcs[cid] = Count(sttcs[cid][0].count_id,
-                               sttcs[cid][0].centreline_id,
-                               sttcs[cid][0].direction,
-                               unified_data, is_permanent=False)
+    return rdr

--- a/traffic_prophet/countmatch/tests/test_reader.py
+++ b/traffic_prophet/countmatch/tests/test_reader.py
@@ -10,166 +10,39 @@ class TestRawAnnualCount:
     """Test preprocessing routines in RawAnnualCount."""
 
     def setup(self):
-        rdr = reader.Reader(SAMPLE_ZIP)
+        rdr = reader.ReaderZip(SAMPLE_ZIP)
         zr = rdr.get_zipreader(SAMPLE_ZIP['2010'])
-        self.counts = list(zr)
-        self.sttc_data = self.counts[2]
-        self.ptc_data = self.counts[7]
-
-    def test_regularize_timeseries(self):
-        # Test processing a file that has no rounding issues.
-        ac = reader.RawAnnualCount(999, 1000, -1, 2010, None)
-        crd = ac.regularize_timeseries(self.ptc_data)
-        assert (sorted(crd.columns) ==
-                sorted(['Timestamp', 'Date', 'Count']))
-        assert crd.shape == (self.ptc_data['data'].shape[0], 3)
-        assert np.array_equal(crd['Timestamp'].dt.minute.unique(),
-                              np.array([0, 15, 30, 45]))
-        assert np.all(crd['Count'] ==
-                      self.ptc_data['data']['Count'].astype(float))
-
-        # Introduce some errors to sttc_data.
-        fake_sttc_data = self.sttc_data.copy()
-        # Do a deep copy just in case.
-        fake_sttc_data['data'] = self.sttc_data['data'].copy()
-        fake_sttc_data['data'].at[30, 'Timestamp'] = (
-            pd.Timestamp('2010-06-09 07:39:31'))
-        fake_sttc_data['data'].at[30, 'Count'] = 235
-        fake_sttc_data['data'].at[32, 'Timestamp'] = (
-            pd.Timestamp('2010-06-09 07:51:12'))
-        crd2 = ac.regularize_timeseries(fake_sttc_data)
-        assert crd2.shape == (self.sttc_data['data'].shape[0] - 2, 3)
-        assert np.array_equal(crd2['Timestamp'].dt.minute.unique(),
-                              np.array([0, 15, 30, 45]))
-        assert crd2.at[30, 'Timestamp'] == pd.Timestamp('2010-06-09 07:45:00')
-        assert np.isclose(crd2.at[30, 'Count'], 93., rtol=1e-10)
-
-    def test_process_15min_count_data(self):
-        ac = reader.RawAnnualCount(999, 1000, -1, 2010, None)
-        crd = ac.regularize_timeseries(self.ptc_data)
-        daily_count = ac.process_15min_count_data(crd)
-        ac.reset_daily_count_index(daily_count)
-
-        # Ensure every unique date is represented.
-        assert daily_count.shape == (crd['Date'].unique().shape[0], 2)
-        assert not np.any(daily_count.index.duplicated())
-
-        # Check that index values represent days of year.
-        assert np.array_equal(daily_count.index.values,
-                              daily_count['Date'].dt.dayofyear)
-
-        # Fuzz test to see if we've summed the counts up properly.
-        for cidx in np.random.choice(daily_count.index.values, size=10):
-            cdate = daily_count.at[cidx, 'Date'].date()
-            assert np.isclose(
-                daily_count.at[cidx, 'Daily Count'],
-                crd.loc[crd['Date'] == cdate, 'Count'].sum(),
-                rtol=1e-10)
-
-        # Check that days with too few counts don't end up in daily counts.
-        # crd_partial has the first three full days of the year, with 73 counts
-        # on the second day removed.
-        crd_partial = (crd.iloc[:288, :]
-                       .drop(index=range(108, 181))
-                       .reset_index(drop=True))
-        assert np.array_equal(
-            crd_partial['Timestamp'].dt.dayofyear.unique(),
-            np.array([1, 2, 3]))
-        daily_count_partial = ac.process_15min_count_data(crd_partial)
-        assert np.array_equal(daily_count_partial['Date'].dt.dayofyear,
-                              np.array([1, 3]))
-
-    def test_is_permanent(self):
-        known_ptc_ids = [890, 104870]
-        ac = reader.RawAnnualCount(999, 1000, -1, 2010, None)
-        for c in self.counts:
-            if c['centreline_id'] in known_ptc_ids:
-                assert ac.is_permanent_count(self.ptc_data)
-            else:
-                assert not ac.is_permanent_count(self.sttc_data)
-
-    def test_process_permanent_count_data(self):
-        ac = reader.RawAnnualCount(999, 1000, -1, 2010, None)
-        # We'll use only one day from December to check what the algorithm will
-        # do in the case of sparse data.
-        temp_data = self.ptc_data.copy()
-        temp_data['data'] = self.ptc_data['data'].loc[:24863, :].copy()
-        dc = ac.process_15min_count_data(
-            ac.regularize_timeseries(temp_data))
-        po = ac.process_permanent_count_data(dc)
-        # These are only available internally in process_permanent_count_data,
-        # so recalculate here.
-        dc['Month'] = dc['Date'].dt.month
-        dc['Day of Week'] = dc['Date'].dt.dayofweek
-
-        po_m = po['MADT']
-        assert ((po_m['MADT'] *
-                 dc.groupby('Month')['Daily Count'].count()).sum() ==
-                dc['Daily Count'].sum())
-        # 2010 is not a leap year.
-        assert po_m['Days in Month'].sum() == 365
-
-        # Every month and day of week must be included in domadt.
-        assert po['DoMADT'].shape == (12, 7)
-        dc_domg = dc.groupby(['Month', 'Day of Week'])
-        n_dom = dc_domg['Daily Count'].count().unstack()
-        sum_dom = dc_domg['Daily Count'].sum().unstack()
-        assert np.allclose(po['DoMADT'] * n_dom, sum_dom,
-                           rtol=1e-10, equal_nan=True)
-
-        # Check that we can recover MADT from DoMADT using DoM Factor.
-        assert po['DoM Factor'].shape == (12, 7)
-        po_factortimesdom = (po['DoM Factor'] * po['DoMADT']).values
-        repeated_madt = np.repeat(po['MADT']['MADT'].values[:, np.newaxis],
-                                  7, axis=1)
-        assert np.allclose(po_factortimesdom[:11, :],
-                           repeated_madt[:11, :], rtol=1e-10)
-        # Only Wednesday, Dec 1 is available in December.
-        dec1_dow = dc.iat[-1, 0].dayofweek
-        assert np.isclose(po_factortimesdom[11, dec1_dow],
-                          repeated_madt[11, dec1_dow])
-
-        # Explicitly check that days with no data are NaN.  First, get all
-        # days of the week other than the one for Dec 1.
-        weekdays_not_dec1 = list(set(range(7)) - set((dec1_dow, )))
-        assert np.all(np.isnan(po['DoMADT'].iloc[-1, weekdays_not_dec1]))
-        assert np.all(np.isnan(po['DoM Factor'].iloc[-1, weekdays_not_dec1]))
-
-        aadt = ((po['MADT']['MADT'] *
-                 po['MADT']['Days in Month']).sum() /
-                po['MADT']['Days in Month'].sum())
-        assert np.isclose(po['AADT'], aadt, rtol=1e-10)
+        self.data = rdr.preprocess_count_data(list(zr)[7])
 
     def test_from_raw_data(self):
-        sttc_ac = reader.RawAnnualCount.from_raw_data(self.sttc_data)
+        sttc_ac = reader.RawAnnualCount.from_raw_data(self.data)
         assert isinstance(sttc_ac, reader.RawAnnualCount)
-        assert sttc_ac.centreline_id == self.sttc_data['centreline_id']
-        assert sttc_ac.direction == self.sttc_data['direction']
-        assert sttc_ac.year == self.sttc_data['year']
+        assert sttc_ac.centreline_id == self.data['centreline_id']
+        assert sttc_ac.direction == self.data['direction']
+        assert sttc_ac.year == self.data['year']
         assert isinstance(sttc_ac.data, pd.DataFrame)
 
-        ptc_ac = reader.RawAnnualCount.from_raw_data(self.ptc_data)
-        assert isinstance(ptc_ac.data, dict)
-        assert (sorted(ptc_ac.data.keys()) ==
-                sorted(['Daily Count', 'MADT', 'DoMADT',
-                        'DoM Factor', 'AADT']))
 
+class TestReaderZip:
+    """Test ReaderZip for reading in sequences of counts.
 
-class TestReader:
-    """Test Reader for reading in sequences of counts."""
+    Also test ReaderBase, since that cannot easily be tested standalone.
+    """
+
+    def setup(self):
+        rdr = reader.ReaderZip(SAMPLE_ZIP)
+        zr = rdr.get_zipreader(SAMPLE_ZIP['2010'])
+        self.counts = list(zr)
 
     def test_initialization(self):
         expected_list = sorted(list(SAMPLE_ZIP.values()))
 
-        rdr = reader.Reader(SAMPLE_ZIP)
-        assert rdr.sourcetype == 'Zip'
-        assert rdr._reader == rdr.read_zip
+        rdr = reader.ReaderZip(SAMPLE_ZIP)
         assert rdr.source == expected_list
 
         # Try again but with a string.
         path = "/".join(SAMPLE_ZIP['2010'].split("/")[:-1]) + "/"
-        rdr = reader.Reader(path + "15_min*.zip")
-        assert rdr._reader == rdr.read_zip
+        rdr = reader.ReaderZip(path + "15_min*.zip")
         assert rdr.source == expected_list
 
         # Try again but with a list.
@@ -177,17 +50,14 @@ class TestReader:
                   path + "15_min_counts_2011_pos_sample.zip",
                   path + "15_min_counts_2012_neg_sample.zip",
                   path + "15_min_counts_2010_neg_sample.zip"]
-        rdr = reader.Reader(sample)
-        assert rdr._reader == rdr.read_zip
+        rdr = reader.ReaderZip(sample)
         assert rdr.source == expected_list
 
     def test_get_zipreader(self):
-        rdr = reader.Reader(SAMPLE_ZIP)
-        zr = rdr.get_zipreader(SAMPLE_ZIP['2010'])
-        counts = list(zr)
+        # self.counts was already generated at setup; this checks its output.
 
-        assert len(counts) == 8
-        assert ([c['filename'] for c in counts] ==
+        assert len(self.counts) == 8
+        assert ([c['filename'] for c in self.counts] ==
                 ['104870_11510_2010.txt',
                  '241_4372_2010.txt',
                  '252_4505_2010.txt',
@@ -196,121 +66,233 @@ class TestReader:
                  '446378_2398_2010.txt',
                  '487_9229_2010.txt',
                  '890_17700_2010.txt'])
-        assert ([c['centreline_id'] for c in counts] ==
+        assert ([c['centreline_id'] for c in self.counts] ==
                 [104870, 241, 252, 410, 427, 446378, 487, 890])
-        assert ([c['direction'] for c in counts] ==
-                [-1 for i in range(len(counts))])
-        assert ([c['data'].shape for c in counts] ==
+        assert ([c['direction'] for c in self.counts] ==
+                [-1 for i in range(len(self.counts))])
+        assert ([c['data'].shape for c in self.counts] ==
                 [(30912, 2), (288, 2), (96, 2), (96, 2), (96, 2), (10752, 2),
                  (288, 2), (27072, 2)])
         assert np.array_equal(
-            counts[2]['data'].dtypes.values,
+            self.counts[2]['data'].dtypes.values,
             np.array([np.dtype('<M8[ns]'), np.dtype('int64')]))
-        assert (counts[2]['data'].at[3, 'Timestamp'] ==
+        assert (self.counts[2]['data'].at[3, 'Timestamp'] ==
                 pd.to_datetime('2010-06-09 00:45:00'))
-        assert counts[2]['data'].at[10, 'Count'] == 1
+        assert self.counts[2]['data'].at[10, 'Count'] == 1
 
         # TO DO: once we get a logger going, should probably also check using a
         # tmpdir that we can ignore and log counts too small to be used.
 
+    def test_regularize_timeseries(self):
+        # Test processing a file that has no rounding issues.
+        rdr = reader.ReaderZip(SAMPLE_ZIP)
+
+        # counts[7] is -890 for 2010 (holdover from an earlier generation of
+        # test suite).
+        ref_data = self.counts[7]
+
+        crd = rdr.regularize_timeseries(ref_data)
+        assert (sorted(crd.columns) ==
+                sorted(['Timestamp', 'Count']))
+        assert crd.shape == (ref_data['data'].shape[0], 2)
+        assert np.array_equal(crd['Timestamp'].dt.minute.unique(),
+                              np.array([0, 15, 30, 45]))
+        assert np.all(crd['Count'] ==
+                      ref_data['data']['Count'].astype(float))
+
+        # Introduce some errors to counts[2] (also a holdover).
+        fake_data = self.counts[2].copy()
+        # Do a deep copy just in case.
+        fake_data['data'] = fake_data['data'].copy()
+        fake_data['data'].at[30, 'Timestamp'] = (
+            pd.Timestamp('2010-06-09 07:39:31'))
+        fake_data['data'].at[30, 'Count'] = 235
+        fake_data['data'].at[32, 'Timestamp'] = (
+            pd.Timestamp('2010-06-09 07:51:12'))
+        crd2 = rdr.regularize_timeseries(fake_data)
+        assert crd2.shape == (self.counts[2]['data'].shape[0] - 2, 2)
+        assert np.array_equal(crd2['Timestamp'].dt.minute.unique(),
+                              np.array([0, 15, 30, 45]))
+        assert crd2.at[30, 'Timestamp'] == pd.Timestamp('2010-06-09 07:45:00')
+        assert np.isclose(crd2.at[30, 'Count'], 93., rtol=1e-10)
+
+    def test_preprocess_count_data(self):
+        rdr = reader.ReaderZip(SAMPLE_ZIP)
+        ref = self.counts[7]
+        rd = ref.copy()
+        # Do a deep copy because preprocess_count_data is not idempotent.
+        rd['data'] = rd['data'].copy()
+
+        rd = rdr.preprocess_count_data(rd)
+
+        # Ensure every unique date is represented.
+        assert rd['data'].shape == (
+            ref['data']['Timestamp'].dt.date.unique().shape[0], 2)
+        assert not np.any(rd['data'].index.duplicated())
+
+        # Check that index values represent days of year.
+        assert np.array_equal(rd['data'].index.values,
+                              rd['data']['Date'].dt.dayofyear)
+
+        # Fuzz test to see if we've summed the counts up properly.
+        for cidx in np.random.choice(rd['data'].index.values, size=10):
+            cdate = rd['data'].at[cidx, 'Date'].date()
+            assert np.isclose(
+                rd['data'].at[cidx, 'Daily Count'],
+                ref['data'].loc[(ref['data']['Timestamp'].dt.date ==
+                                 cdate), 'Count'].sum(),
+                rtol=1e-10)
+
+        # Check that days with too few counts don't end up in daily counts.
+        # crd_partial has the first three full days of the year, with 73 counts
+        # on the second day removed.
+        rdd_partial = (ref['data'].iloc[:288, :]
+                       .drop(index=range(108, 181))
+                       .reset_index(drop=True))
+        assert np.array_equal(
+            rdd_partial['Timestamp'].dt.dayofyear.unique(),
+            np.array([1, 2, 3]))
+        rdp = ref.copy()
+        rdp['data'] = rdd_partial
+        rdp = rdr.preprocess_count_data(rdp)
+        assert np.array_equal(rdp['data']['Date'].dt.dayofyear,
+                              np.array([1, 3]))
+
     def test_append_counts(self):
-        rdr = reader.Reader(SAMPLE_ZIP)
-        counts_2010 = [reader.RawAnnualCount.from_raw_data(c)
-                       for c in rdr.get_zipreader(SAMPLE_ZIP['2010'])]
-        counts_2012 = [reader.RawAnnualCount.from_raw_data(c)
-                       for c in rdr.get_zipreader(SAMPLE_ZIP['2012'])]
-        ptcs = {}
-        sttcs = {}
-        rdr.append_counts(counts_2010, ptcs, sttcs)
-        rdr.append_counts(counts_2012, ptcs, sttcs)
+        rdr = reader.ReaderZip(SAMPLE_ZIP)
+        counts_2010 = [
+            reader.RawAnnualCount.from_raw_data(
+                rdr.preprocess_count_data(c))
+            for c in rdr.get_zipreader(SAMPLE_ZIP['2010'])]
+        counts_2012 = [
+            reader.RawAnnualCount.from_raw_data(
+                rdr.preprocess_count_data(c))
+            for c in rdr.get_zipreader(SAMPLE_ZIP['2012'])]
+        counts = {}
+        rdr.append_counts(counts_2010, counts)
+        rdr.append_counts(counts_2012, counts)
 
         # Annoyingly, there is no overlap in PTC locations between 2010
         # and 2011.
-        assert sorted(ptcs.keys()) == [-104870, -890]
-        assert (sorted(sttcs.keys()) ==
-                [-446378, -1978, -890, -487, -427, -410, -252, -241])
+        assert (sorted(counts.keys()) ==
+                [-446378, -104870, -1978, -890, -487, -427, -410, -252, -241])
 
         # Check that counts from multiple years are stored under the same key.
-        assert len(ptcs[-104870]) == 2
-        assert len(sttcs[-241]) == 2
+        assert len(counts[-104870]) == 2
+        assert len(counts[-241]) == 2
 
         # Check table integrity.
-        assert (counts_2010[0].data['DoMADT']
-                .equals(ptcs[-104870][0].data['DoMADT']))
-        assert (counts_2012[4].data['Daily Count']
-                .equals(sttcs[-890][0].data['Daily Count']))
-
-    def test_check_processed_count_integrity(self):
-        rdr = reader.Reader(SAMPLE_ZIP)
-        with pytest.raises(ValueError) as exc:
-            rdr.check_processed_count_integrity(ptcs={}, sttcs={})
-        assert "no count file has more than" in str(exc.value)
+        assert counts_2010[0].data.equals(counts[-104870][0].data)
+        assert counts_2012[4].data.equals(counts[-890][1].data)
 
     def test_unify_counts(self):
-        rdr = reader.Reader(SAMPLE_ZIP)
-        counts_2010 = [reader.RawAnnualCount.from_raw_data(c)
-                       for c in rdr.get_zipreader(SAMPLE_ZIP['2010'])]
-        counts_2011p = [reader.RawAnnualCount.from_raw_data(c)
-                        for c in rdr.get_zipreader(SAMPLE_ZIP['2011p'])]
-        counts_2012 = [reader.RawAnnualCount.from_raw_data(c)
-                       for c in rdr.get_zipreader(SAMPLE_ZIP['2012'])]
-        ptcs = {}
-        sttcs = {}
-        rdr.append_counts(counts_2010, ptcs, sttcs)
-        rdr.append_counts(counts_2011p, ptcs, sttcs)
-        rdr.append_counts(counts_2012, ptcs, sttcs)
+        rdr = reader.ReaderZip(SAMPLE_ZIP)
+        counts_2010 = [
+            reader.RawAnnualCount.from_raw_data(
+                rdr.preprocess_count_data(c))
+            for c in rdr.get_zipreader(SAMPLE_ZIP['2010'])]
+        counts_2011p = [
+            reader.RawAnnualCount.from_raw_data(
+                rdr.preprocess_count_data(c))
+            for c in rdr.get_zipreader(SAMPLE_ZIP['2011p'])]
+        counts_2012 = [
+            reader.RawAnnualCount.from_raw_data(
+                rdr.preprocess_count_data(c))
+            for c in rdr.get_zipreader(SAMPLE_ZIP['2012'])]
 
-        rdr.unify_counts(ptcs, sttcs)
+        counts = {}
+        rdr.append_counts(counts_2010, counts)
+        rdr.append_counts(counts_2011p, counts)
+        rdr.append_counts(counts_2012, counts)
 
-        assert sorted(ptcs.keys()) == [-104870, -890]
-        assert (sorted(sttcs.keys()) ==
-                [-446378, -1978, -890, -487, -427, -410, -252, -241,
+        rdr.unify_counts(counts)
+
+        assert (sorted(counts.keys()) ==
+                [-446378, -104870, -1978, -890, -487, -427, -410, -252, -241,
                  170, 104870])
         # Check that we've concatenated three years' data together.
-        # `unify_counts` is not idempotent and alters `ptcs` and `sttcs`.
-        # Since those do not make copies of data from `counts_2010` and
-        # `counts_2012`, those are altered as well.  This only matters for
-        # testing, however.
-        assert ptcs[-104870].count_id == -104870
-        assert ptcs[-104870].centreline_id == 104870
-        assert ptcs[-104870].direction == -1
-        assert ptcs[-104870].is_permanent
-        assert ptcs[-104870].data['DoM Factor'].equals(
-            pd.concat([counts_2010[0].data['DoM Factor'],
-                       counts_2012[0].data['DoM Factor']]))
+        # `unify_counts` is not idempotent and alters `counts`. Since those do
+        # not make copies of data from `counts_2010` and `counts_2012`, those
+        # are altered as well.  This only matters for testing, however.
+        assert counts[-104870].count_id == -104870
+        assert counts[-104870].centreline_id == 104870
+        assert counts[-104870].direction == -1
+        # No count should be labeled permanent yet.
+        assert not counts[-104870].is_permanent
+        assert counts[-104870].data.equals(
+            pd.concat([counts_2010[0].data, counts_2012[0].data]))
 
-        assert sttcs[-241].count_id == -241
-        assert sttcs[-241].centreline_id == 241
-        assert sttcs[-241].direction == -1
-        assert not sttcs[-241].is_permanent
-        assert sttcs[-241].data.equals(
+        assert counts[-241].count_id == -241
+        assert counts[-241].centreline_id == 241
+        assert counts[-241].direction == -1
+        assert not counts[-241].is_permanent
+        assert counts[-241].data.equals(
             pd.concat([counts_2010[1].data, counts_2012[2].data]))
 
-        assert sttcs[170].count_id == 170
-        assert sttcs[170].centreline_id == 170
-        assert sttcs[170].direction == 1
-        assert not sttcs[170].is_permanent
-        assert sttcs[170].data.equals(counts_2011p[0].data)
+        assert counts[170].count_id == 170
+        assert counts[170].centreline_id == 170
+        assert counts[170].direction == 1
+        assert not counts[170].is_permanent
+        assert counts[170].data.equals(counts_2011p[0].data)
 
-    def test_read_zip(self):
-        rdr = reader.Reader(SAMPLE_ZIP)
+    def test_read(self):
+        rdr = reader.ReaderZip(SAMPLE_ZIP)
         rdr.read()
 
-        assert sorted(rdr.ptcs.keys()) == [-104870, -890]
-        assert (sorted(rdr.sttcs.keys()) ==
+        assert (sorted(rdr.counts.keys()) ==
                 [-446378, -104870, -1978, -890, -680, -487, -427, -410,
                  -252, -241, -170, 170, 104870])
-        assert isinstance(rdr.ptcs[-104870], reader.Count)
-        assert isinstance(rdr.sttcs[-241], reader.Count)
+        assert isinstance(rdr.counts[-241], reader.Count)
 
         # Check that all available years have been read in.
         included_years = []
-        for key in rdr.sttcs.keys():
-            included_years += list(rdr.sttcs[key].data.index.levels[0].values)
+        for key in rdr.counts.keys():
+            included_years += list(rdr.counts[key].data.index.levels[0].values)
         assert sorted(list(set(included_years))) == [2010, 2011, 2012]
 
         # Check that reading a non-zip raises an error.
         with pytest.raises(IOError):
             path = "/".join(SAMPLE_ZIP['2010'].split("/")[:-1]) + "/"
-            rdr = reader.Reader(path + 'count_lonlat.csv')
-            rdr.read_zip()
+            rdr = reader.ReaderZip(path + 'count_lonlat.csv')
+            rdr.read()
+
+
+class TestReaderPostgres:
+    """Test ReaderPostgres for reading in sequences of counts.
+
+    Currently only `preprocess_count_data` can be tested, since everything else
+    requires a test Postgres DB to be set up during testing.
+    """
+
+    def setup(self):
+        rdrz = reader.ReaderZip(SAMPLE_ZIP)
+        zr = rdrz.get_zipreader(SAMPLE_ZIP['2010'])
+        self.counts = list(zr)
+
+    def test_initialization(self):
+        rdr = reader.ReaderPostgres('Placeholder')
+        assert rdr.counts is None
+        assert rdr.source == 'Placeholder'
+
+    def test_preprocess_count_data(self):
+        rdr = reader.ReaderPostgres(SAMPLE_ZIP)
+        # Emulate daily count raw data from Postgres.
+        rd = self.counts[7].copy()
+        rd['data'] = rd['data'].copy()
+        rd['data']['Date'] = rd['data']['Timestamp'].dt.date
+        crdg = rd['data'].groupby('Date')
+        daily_count = pd.DataFrame({
+            'Daily Count': 96. * crdg['Count'].mean()})
+        daily_count.reset_index(inplace=True)
+        daily_count['Date'] = pd.to_datetime(daily_count['Date'])
+        rd['data'] = daily_count
+
+        # Preprocess count data.
+        rd = rdr.preprocess_count_data(rd)
+
+        # Ensure every unique date is represented.
+        assert not np.any(rd['data'].index.duplicated())
+
+        # Check that index values represent days of year.
+        assert np.array_equal(rd['data'].index.values,
+                              rd['data']['Date'].dt.dayofyear)

--- a/traffic_prophet/countmatch/tests/test_reader.py
+++ b/traffic_prophet/countmatch/tests/test_reader.py
@@ -296,3 +296,14 @@ class TestReaderPostgres:
         # Check that index values represent days of year.
         assert np.array_equal(rd['data'].index.values,
                               rd['data']['Date'].dt.dayofyear)
+
+
+class TestReaderFunction:
+    """Test reader function for returning the right class."""
+
+    def test_reader(self):
+        rdr = reader.read(SAMPLE_ZIP['2011p'])
+        assert sorted(rdr.counts.keys()) == [170, 104870]
+        assert rdr.counts[104870].data.shape == (3, 2)
+        assert (rdr.counts[104870].data.index.levels[0].values ==
+                np.array([2011]))

--- a/traffic_prophet/countmatch/tests/test_reader.py
+++ b/traffic_prophet/countmatch/tests/test_reader.py
@@ -6,8 +6,8 @@ from ...data import SAMPLE_ZIP
 from .. import reader
 
 
-class TestAnnualCount:
-    """Test preprocessing routines in AnnualCount."""
+class TestRawAnnualCount:
+    """Test preprocessing routines in RawAnnualCount."""
 
     def setup(self):
         rdr = reader.Reader(SAMPLE_ZIP)
@@ -18,7 +18,7 @@ class TestAnnualCount:
 
     def test_regularize_timeseries(self):
         # Test processing a file that has no rounding issues.
-        ac = reader.AnnualCount(999, 1000, -1, 2010, None)
+        ac = reader.RawAnnualCount(999, 1000, -1, 2010, None)
         crd = ac.regularize_timeseries(self.ptc_data)
         assert (sorted(crd.columns) ==
                 sorted(['Timestamp', 'Date', 'Count']))
@@ -45,7 +45,7 @@ class TestAnnualCount:
         assert np.isclose(crd2.at[30, 'Count'], 93., rtol=1e-10)
 
     def test_process_15min_count_data(self):
-        ac = reader.AnnualCount(999, 1000, -1, 2010, None)
+        ac = reader.RawAnnualCount(999, 1000, -1, 2010, None)
         crd = ac.regularize_timeseries(self.ptc_data)
         daily_count = ac.process_15min_count_data(crd)
         ac.reset_daily_count_index(daily_count)
@@ -81,7 +81,7 @@ class TestAnnualCount:
 
     def test_is_permanent(self):
         known_ptc_ids = [890, 104870]
-        ac = reader.AnnualCount(999, 1000, -1, 2010, None)
+        ac = reader.RawAnnualCount(999, 1000, -1, 2010, None)
         for c in self.counts:
             if c['centreline_id'] in known_ptc_ids:
                 assert ac.is_permanent_count(self.ptc_data)
@@ -89,7 +89,7 @@ class TestAnnualCount:
                 assert not ac.is_permanent_count(self.sttc_data)
 
     def test_process_permanent_count_data(self):
-        ac = reader.AnnualCount(999, 1000, -1, 2010, None)
+        ac = reader.RawAnnualCount(999, 1000, -1, 2010, None)
         # We'll use only one day from December to check what the algorithm will
         # do in the case of sparse data.
         temp_data = self.ptc_data.copy()
@@ -141,14 +141,14 @@ class TestAnnualCount:
         assert np.isclose(po['AADT'], aadt, rtol=1e-10)
 
     def test_from_raw_data(self):
-        sttc_ac = reader.AnnualCount.from_raw_data(self.sttc_data)
-        assert isinstance(sttc_ac, reader.AnnualCount)
+        sttc_ac = reader.RawAnnualCount.from_raw_data(self.sttc_data)
+        assert isinstance(sttc_ac, reader.RawAnnualCount)
         assert sttc_ac.centreline_id == self.sttc_data['centreline_id']
         assert sttc_ac.direction == self.sttc_data['direction']
         assert sttc_ac.year == self.sttc_data['year']
         assert isinstance(sttc_ac.data, pd.DataFrame)
 
-        ptc_ac = reader.AnnualCount.from_raw_data(self.ptc_data)
+        ptc_ac = reader.RawAnnualCount.from_raw_data(self.ptc_data)
         assert isinstance(ptc_ac.data, dict)
         assert (sorted(ptc_ac.data.keys()) ==
                 sorted(['Daily Count', 'MADT', 'DoMADT',
@@ -215,9 +215,9 @@ class TestReader:
 
     def test_append_counts(self):
         rdr = reader.Reader(SAMPLE_ZIP)
-        counts_2010 = [reader.AnnualCount.from_raw_data(c)
+        counts_2010 = [reader.RawAnnualCount.from_raw_data(c)
                        for c in rdr.get_zipreader(SAMPLE_ZIP['2010'])]
-        counts_2012 = [reader.AnnualCount.from_raw_data(c)
+        counts_2012 = [reader.RawAnnualCount.from_raw_data(c)
                        for c in rdr.get_zipreader(SAMPLE_ZIP['2012'])]
         ptcs = {}
         sttcs = {}
@@ -248,11 +248,11 @@ class TestReader:
 
     def test_unify_counts(self):
         rdr = reader.Reader(SAMPLE_ZIP)
-        counts_2010 = [reader.AnnualCount.from_raw_data(c)
+        counts_2010 = [reader.RawAnnualCount.from_raw_data(c)
                        for c in rdr.get_zipreader(SAMPLE_ZIP['2010'])]
-        counts_2011p = [reader.AnnualCount.from_raw_data(c)
+        counts_2011p = [reader.RawAnnualCount.from_raw_data(c)
                         for c in rdr.get_zipreader(SAMPLE_ZIP['2011p'])]
-        counts_2012 = [reader.AnnualCount.from_raw_data(c)
+        counts_2012 = [reader.RawAnnualCount.from_raw_data(c)
                        for c in rdr.get_zipreader(SAMPLE_ZIP['2012'])]
         ptcs = {}
         sttcs = {}


### PR DESCRIPTION
Refactoring of the `reader.py` module so that the only major preprocessing done on read-in is transformation to daily counts from 15-minute ones.  Since this is only done for zip files, moved all zip-specific preprocessing to a `ReaderZip` class, greatly simplifying `AnnualCount` (which is now called `RawAnnualCount`).  Renamed some other classes and methods to better reflect what they do.

Addresses #21.