### PR TITLE
Refactor How Config Values are Passed

### DIFF
--- a/traffic_prophet/countmatch/reader.py
+++ b/traffic_prophet/countmatch/reader.py
@@ -275,10 +275,7 @@ class ReaderPostgres(ReaderBase):
 
 
 def read(source):
-
     rdr = (ReaderPostgres(source) if isinstance(source, conn.Connection)
            else ReaderZip(source))
-
     rdr.read()
-
     return rdr

--- a/traffic_prophet/countmatch/reader.py
+++ b/traffic_prophet/countmatch/reader.py
@@ -51,7 +51,7 @@ class ReaderBase:
         # Store permanent and temporary stations.
         self.counts = None
         self.source = source
-        self.cfg = cfg.cm
+        self.cfg = cfgcm
 
     def read(self):
         """Read source data into a dictionary of counts."""


### PR DESCRIPTION
Ideally, all of the classes and functions that use configuration settings from `config.py` would use it by default, but also allow for a per-instance user override.  This would allow us to do hyperparameter tuning and diagnostics.

Modified calls to `cfg.cm` in `Reader` classes to instead read from `self.cfg`, an instance attribute.  `self.cfg` is set by a keyword argument of `__init__` that defaults to `cfg.cm`.  According to [Python scope rules](https://sebastianraschka.com/Articles/2014_python_scope_and_namespaces.html), if the keyword isn't set, the class instance will use `cfg.cm`, and reflect any user changes to `cfg.cm` (by doing something like `import config as cfg; cfg.cm['variable'] = ...`).