### PR TITLE
CountMatch Refactoring

### DIFF
--- a/traffic_prophet/config.py
+++ b/traffic_prophet/config.py
@@ -4,15 +4,17 @@
 
 # For countmatch
 cm = {
-    'min_stn_count': 96,
+    'min_count': 96,
     'min_counts_in_day': 24,
-    'min_permanent_stn_days': 274,
+    'min_permanent_months': 12,
+    'min_permanent_days': 274,
     'exclude_ptc_neg': [8540609, 446378, 12336151, 5439677, 1145406, 30019302,
                         7094867, 9722624, 439225, 1146926, 1141002, 440202,
                         1147135],
     'exclude_ptc_pos': [446402, 7204532, 1145377, 30029635, 1147358, 106853,
                         1140996, 1797, 14177830, 30073989, 14189397,
                         440428, 14659261],
+    'derived_values_calculator': ''
     'min_year': 2006,
     'max_year': 2018
 }

--- a/traffic_prophet/config.py
+++ b/traffic_prophet/config.py
@@ -14,7 +14,8 @@ cm = {
     'exclude_ptc_pos': [446402, 7204532, 1145377, 30029635, 1147358, 106853,
                         1140996, 1797, 14177830, 30073989, 14189397,
                         440428, 14659261],
-    'derived_values_calculator': ''
+    'growth_factor_calculator': 'Composite',
+    'growth_factor_settings': {},
     'min_year': 2006,
     'max_year': 2018
 }

--- a/traffic_prophet/config.py
+++ b/traffic_prophet/config.py
@@ -4,7 +4,7 @@
 
 # For countmatch
 cm = {
-    'verbose': True,
+    'verbose': False,
     'min_count': 96,
     'min_counts_in_day': 24,
     'min_permanent_months': 12,

--- a/traffic_prophet/config.py
+++ b/traffic_prophet/config.py
@@ -4,6 +4,7 @@
 
 # For countmatch
 cm = {
+    'verbose': True,
     'min_count': 96,
     'min_counts_in_day': 24,
     'min_permanent_months': 12,
@@ -14,6 +15,8 @@ cm = {
     'exclude_ptc_pos': [446402, 7204532, 1145377, 30029635, 1147358, 106853,
                         1140996, 1797, 14177830, 30073989, 14189397,
                         440428, 14659261],
+    'derived_vals_calculator': 'Standard',
+    'derived_vals_settings': {},
     'growth_factor_calculator': 'Composite',
     'growth_factor_settings': {},
     'min_year': 2006,

--- a/traffic_prophet/countmatch/base.py
+++ b/traffic_prophet/countmatch/base.py
@@ -1,1 +1,13 @@
 """Base classes and functions for countmatch."""
+
+
+class Count:
+    """Base class for all count objects."""
+
+    def __init__(self, count_id, centreline_id, direction,
+                 data, is_permanent=False):
+        self.count_id = count_id
+        self.centreline_id = int(centreline_id)
+        self.direction = int(direction)
+        self.is_permanent = bool(is_permanent)
+        self.data = data

--- a/traffic_prophet/countmatch/derivedvals.py
+++ b/traffic_prophet/countmatch/derivedvals.py
@@ -4,7 +4,46 @@ import numpy as np
 import pandas as pd
 
 
-class DerivedValBase:
+DV_REGISTRY = {}
+"""Dict for storing derived value processor class definitions."""
+
+
+class DVRegistrar(type):
+    """Class registry processor, based on `baseband.vdif.header`.
+
+    See https://github.com/mhvk/baseband.
+
+    """
+
+    _registry = DV_REGISTRY
+
+    def __init__(cls, name, bases, dct):
+
+        # Register GrowthFactorBase subclass if `_dv_type` not already taken.
+        if name not in ('DerivedValsBase', 'DerivedVals'):
+            if not hasattr(cls, "_dv_type"):
+                raise ValueError("must define a `_dv_type`.")
+            elif cls._dv_type in DVRegistrar._registry:
+                raise ValueError("name {0} already registered in "
+                                 "DV_REGISTRY".format(cls._dv_type))
+
+            DVRegistrar._registry[cls._dv_type] = cls
+
+        super().__init__(name, bases, dct)
+
+
+class DerivedVals:
+
+    def __new__(cls, dvtype, *args, **kwargs):
+        # __init__ has to be called manually!
+        # https://docs.python.org/3/reference/datamodel.html#object.__new__
+        # https://stackoverflow.com/questions/20221858/python-new-method-returning-something-other-than-class-instance
+        self = super().__new__(DV_REGISTRY[dvtype])
+        self.__init__(*args, **kwargs)
+        return self
+
+
+class DerivedValsBase(metaclass=DVRegistrar):
     """Base class for getting derived values for permanent counts.
 
     Notes
@@ -69,19 +108,33 @@ class DerivedValBase:
 
         # Determine day-to-month conversion factor DoM_ijd.  (Uses a numpy
         # broadcasting trick.)
-        dom_ijd = madt['MADT'].values[:, np.newaxis] / domadt
+        dom_ijd = (madt['MADT'].loc[perm_years, :].values[:, np.newaxis] /
+                   domadt.loc[perm_years, :])
         # Determine day-to-year conversion factor D_ijd.
         d_ijd = (aadt['AADT'].values[:, np.newaxis] /
                  domadt.loc[perm_years, :].unstack(level=-1)).stack()
 
-        return dom_ijd, d_ijd, n_avail_days
+        return domadt, dom_ijd, d_ijd, n_avail_days
 
     def get_derived_vals(self, ptc):
         raise NotImplementedError
 
 
-class DerivedValSimple(DerivedValBase):
+class DerivedValsStandard(DerivedValsBase):
 
-    @staticmethod
-    def get_derived_vals(ptc):
-        pass
+    _dv_type = 'Standard'
+
+    def __init__(self, impute_ratios=False):
+        self._impute_ratios = impute_ratios
+
+    def get_derived_vals(self, ptc):
+        dca = self.preprocess_daily_counts(ptc.data['Daily Count'])
+        madt = self.get_madt(dca)
+        aadt = self.get_aadt_from_madt(madt, ptc.perm_years)
+        domadt, dom_ijd, d_ijd, n_avail_days = self.get_ratios(
+            dca, madt, aadt, ptc.perm_years)
+
+        ptc.data['MADT'] = madt
+        ptc.data['AADT'] = aadt
+        ptc.ratios = {'DoM_ijd': dom_ijd, 'D_ijd': d_ijd,
+                      'N_avail_days': n_avail_days}

--- a/traffic_prophet/countmatch/derivedvals.py
+++ b/traffic_prophet/countmatch/derivedvals.py
@@ -114,7 +114,7 @@ class DerivedValsBase(metaclass=DVRegistrar):
         d_ijd = (aadt['AADT'].values[:, np.newaxis] /
                  domadt.loc[perm_years, :].unstack(level=-1)).stack()
 
-        return domadt, dom_ijd, d_ijd, n_avail_days
+        return dom_ijd, d_ijd, n_avail_days
 
     def get_derived_vals(self, ptc):
         raise NotImplementedError
@@ -131,7 +131,7 @@ class DerivedValsStandard(DerivedValsBase):
         dca = self.preprocess_daily_counts(ptc.data['Daily Count'])
         madt = self.get_madt(dca)
         aadt = self.get_aadt_from_madt(madt, ptc.perm_years)
-        domadt, dom_ijd, d_ijd, n_avail_days = self.get_ratios(
+        dom_ijd, d_ijd, n_avail_days = self.get_ratios(
             dca, madt, aadt, ptc.perm_years)
 
         ptc.data['MADT'] = madt

--- a/traffic_prophet/countmatch/derivedvals.py
+++ b/traffic_prophet/countmatch/derivedvals.py
@@ -1,0 +1,87 @@
+"""Determine derived values (DoM Factors, etc.) from permanent counts."""
+
+import numpy as np
+import pandas as pd
+
+
+class DerivedValBase:
+    """Base class for getting derived values for permanent counts.
+
+    Notes
+    -----
+    Averaging methods are more conservative than `STTC_estimate3.m` - only
+    days with complete data are included in the MADT and DoMADT estimates.
+
+    """
+
+    _months_of_year = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+
+    @staticmethod
+    def preprocess_daily_counts(dc):
+        # Ensure dc remains unchanged by the method.
+        dca = dc.copy()
+        dca['Month'] = dca['Date'].dt.month
+        dca['Day of Week'] = dca['Date'].dt.dayofweek
+        return dca
+
+    def get_madt(self, dca):
+        dc_m = dca.groupby(['Year', 'Month'])
+        madt = pd.DataFrame({
+            'MADT': dc_m['Daily Count'].mean(),
+            'Days Available': dc_m['Daily Count'].count()},
+            index=pd.MultiIndex.from_product(
+                [dca.index.levels[0], np.arange(1, 13, dtype=int)],
+                names=['Year', 'Month'])
+        )
+
+        # Loop to record number of days in month.
+        days_in_month = []
+        for year in dca.index.levels[0]:
+            cdays = self._months_of_year.copy()
+            cdays[1] = pd.to_datetime('{0:d}-02-01'.format(year)).daysinmonth
+            days_in_month += cdays
+        madt['Days in Month'] = days_in_month
+
+        return madt
+
+    @staticmethod
+    def get_aadt_from_madt(madt, perm_years):
+        # Weighted average for AADT.
+        madt_py = madt.loc[perm_years, :]
+        monthly_total_traffic = madt_py['MADT'] * madt_py['Days in Month']
+        return pd.DataFrame(
+            {'AADT': (monthly_total_traffic.groupby('Year').sum() /
+                      madt_py.groupby('Year')['Days in Month'].sum())})
+
+    @staticmethod
+    def get_ratios(dca, madt, aadt, perm_years):
+        dc_dom = dca.groupby(['Year', 'Month', 'Day of Week'])
+        ymd_index = pd.MultiIndex.from_product(
+            [dca.index.levels[0], np.arange(1, 13, dtype=int)],
+            names=['Year', 'Month'])
+
+        domadt = pd.DataFrame(
+            dc_dom['Daily Count'].mean().unstack(level=-1, fill_value=np.nan),
+            index=ymd_index)
+        n_avail_days = pd.DataFrame(
+            dc_dom['Daily Count'].count().unstack(level=-1, fill_value=np.nan),
+            index=ymd_index)
+
+        # Determine day-to-month conversion factor DoM_ijd.  (Uses a numpy
+        # broadcasting trick.)
+        dom_ijd = madt['MADT'].values[:, np.newaxis] / domadt
+        # Determine day-to-year conversion factor D_ijd.
+        d_ijd = (aadt['AADT'].values[:, np.newaxis] /
+                 domadt.loc[perm_years, :].unstack(level=-1)).stack()
+
+        return dom_ijd, d_ijd, n_avail_days
+
+    def get_derived_vals(self, ptc):
+        raise NotImplementedError
+
+
+class DerivedValSimple(DerivedValBase):
+
+    @staticmethod
+    def get_derived_vals(ptc):
+        pass

--- a/traffic_prophet/countmatch/growthfactor.py
+++ b/traffic_prophet/countmatch/growthfactor.py
@@ -3,93 +3,57 @@
 import numpy as np
 import statsmodels.api as sm
 
-from . import reader
+
+GF_REGISTRY = {}
+"""Dict for storing growth factor processor class definitions."""
 
 
-def exponential_rate_fit(year, aadt, ref_vals):
-    """Calculate year-on-year exponential growth rate :math:`r` for ADT.
+class GFRegistrar(type):
+    """Class registry processor, based on `baseband.vdif.header`.
 
-    Parameters
-    ----------
-    year : numpy.ndarray
-        Array of year values.
-    aadt : pandas.DataFrame
-        Array of AADT values.
-    ref_vals : dict containing 'year' and 'aadt' entries.
-        Reference values for normalization.
-    
-    Returns
-    -------
-    r : statsmodels.regression.linear_model.RegressionResultsWrapper
-        Fit results.
+    See https://github.com/mhvk/baseband.
 
-    Notes
-    -----
-
-    AADT for year :math:`y`, :math:`A_\mathrm{t}` is assumed to follow
-
-    ..math::
-        A_\mathrm{y} = A_{y_0} \exp{(r(y - y_0))}
-
-    Where :math:`A_{y_0}` is some baseline AADT and :math:`r` the growth rate
-    in units of :math:`1 / year`.
-
-    See https://www.unescap.org/sites/default/files/Stats_Brief_Apr2015_Issue_07_Average-growth-rate.pdf
-    and https://datahelpdesk.worldbank.org/knowledgebase/articles/906531-methodologies
     """
-    # TO DO: consider relaxing the strict requirement that only r be allowed to
-    # vary?
+    _registry = GF_REGISTRY
 
-    # Dependent variable first.
-    # https://www.statsmodels.org/dev/generated/statsmodels.regression.linear_model.OLS.html
-    model = sm.OLS(endog=(np.log(aadt / ref_vals['aadt'])),
-                   exog=(year - ref_vals['year']))
-    return model.fit()
+    def __init__(cls, name, bases, dct):
 
+        # Register GrowthFactorBase subclass if `_fit_type` not already taken.
+        if name not in ('GrowthFactorBase', 'GrowthFactor'):
+            if not hasattr(cls, "_fit_type"):
+                raise ValueError("must define a `_fit_type`.")
+            elif cls._fit_type in GFRegistrar._registry:
+                raise ValueError("EDV {0} already registered in "
+                                 "GF_REGISTRY".format(cls._fit_type))
 
-def linear_rate_fit(week, wadt):
-    """OLS regression to estimate the linear growth rate within a single year.
+            GFRegistrar._registry[cls._fit_type] = cls
 
-    ADT for week :math:`t`, :math:`A_\mathrm{t}` is assumed to follow
-
-    ..math::
-        A_\mathrm{t} = r(t - t_0) + A_{t_0}
-
-    Where :math:`A_{t_0}` is ADT for a reference year and :math:`r` the
-    growth rate in units of :math:`A / week`.
-
-    Parameters
-    ----------
-    week : numpy.ndarray
-        Array of year values.
-    aadt : pandas.DataFrame
-        Array of AADT values.
-    ref_vals : dict containing 'year' and 'aadt' entries.
-        Reference values for normalization.
-
-    Returns
-    -------
-    r : statsmodels.regression.linear_model.RegressionResultsWrapper
-        Fit results.
-    """
-    model = sm.OLS(endog=wadt, exog=sm.add_constant(week))
-    return model.fit()
+        super().__init__(name, bases, dct)
 
 
-class GrowthFactorBase:
-    """Class to hold permanent count data and calculate growth factors."""
+class GrowthFactor:
 
-    def __init__(self, tc):
-        # Store parent class.
-        self.tc = tc
+    def __new__(cls, proctype, *args, **kwargs):
+        # __init__ has to be called manually!
+        # https://docs.python.org/3/reference/datamodel.html#object.__new__
+        # https://stackoverflow.com/questions/20221858/python-new-method-returning-something-other-than-class-instance
+        self = super().__new__(GF_REGISTRY[proctype])
+        self.__init__(*args, **kwargs)
+        return self
 
-    def get_aadt(self):
-        aadt = self.data['AADT'].reset_index()
+
+class GrowthFactorBase(metaclass=GFRegistrar):
+    """Base class for calculating growth factors."""
+
+    @staticmethod
+    def get_aadt(tc):
+        aadt = tc.data['AADT'].reset_index()
         aadt['Year'] = aadt['Year'].astype(float)
         return aadt
 
-    def get_wadt(self):
-        cdata = self.data['Daily Count'].reset_index()
+    @staticmethod
+    def get_wadt(tc):
+        cdata = tc.data['Daily Count'].reset_index()
         # Overcomplicated groupby using the start of the week, as dt.week
         # returns the "week ordinal".  See https://stackoverflow.com/a/55890652
         cdata['Start of Week'] = (
@@ -103,30 +67,134 @@ class GrowthFactorBase:
         wadt['Week'] = wadt['Start of Week'].dt.week.astype(float)
         return wadt
 
-    def fit_growth(self):
-        if len(self.data['DoMADT'].index.levels[0]) > 1:
-            self._fit_type = 'Exponential'
+    def fit_growth(self, tc):
+        raise NotImplementedError
 
-            # Process year vs. AADT data.
-            aadt = self.get_aadt()
 
-            # Perform exponential fit.
-            self._fit = exponential_rate_fit(
-                aadt['Year'].values,
-                aadt['AADT'].values,
-                {'year': aadt.at[0, 'Year'], 'aadt': aadt.at[0, 'AADT']})
+class GrowthFactorAADTExp(GrowthFactorBase):
 
-            # Populate growth factor.
-            self.growth_factor = np.exp(self._fit.params[0])
-        else:
-            self._fit_type = 'Linear'
+    _fit_type = 'AADTExp'
 
-            # Process week vs. weekly averaged ADT.
-            wadt = self.get_wadt()
-            self._fit = linear_rate_fit(wadt['Week'].values,
-                                        wadt['WADT'].values)
+    @staticmethod
+    def exponential_rate_fit(year, aadt, ref_vals):
+        r"""Calculate year-on-year exponential growth rate :math:`r` for ADT.
 
-            # Convert linear weekly fit to yearly exponential fit (iffy logic).
-            aadt_info = self.data['AADT'].reset_index()
-            self.growth_factor = 1. + (self._fit.params[1] * 52. /
-                                       aadt_info['AADT'].values[0])
+        Parameters
+        ----------
+        year : numpy.ndarray
+            Array of year values.
+        aadt : pandas.DataFrame
+            Array of AADT values.
+        ref_vals : dict containing 'year' and 'aadt' entries.
+            Reference values for normalization.
+
+        Returns
+        -------
+        r : statsmodels.regression.linear_model.RegressionResultsWrapper
+            Fit results.
+
+        Notes
+        -----
+        AADT for year :math:`y`, :math:`A_\mathrm{t}` is assumed to follow
+
+        ..math::
+            A_\mathrm{y} = A_{y_0} \exp{(r(y - y_0))}
+
+        Where :math:`A_{y_0}` is some baseline AADT and :math:`r` the
+        growthrate in units of :math:`1 / year`.
+
+        See https://www.unescap.org/sites/default/files/Stats_Brief_Apr2015_Issue_07_Average-growth-rate.pdf
+        and https://datahelpdesk.worldbank.org/knowledgebase/articles/906531-methodologies
+
+        """
+        # TO DO: consider relaxing the strict requirement that only r be
+        # allowed to vary?
+
+        # Dependent variable first.
+        # https://www.statsmodels.org/dev/generated/statsmodels.regression.linear_model.OLS.html
+        model = sm.OLS(endog=(np.log(aadt / ref_vals['aadt'])),
+                       exog=(year - ref_vals['year']))
+        return model.fit()
+
+    def fit_growth(self, tc):
+        # Process year vs. AADT data.
+        aadt = self.get_aadt(tc)
+
+        # Perform exponential fit.
+        fit_results = self.exponential_rate_fit(
+            aadt['Year'].values,
+            aadt['AADT'].values,
+            {'year': aadt.at[0, 'Year'], 'aadt': aadt.at[0, 'AADT']})
+        growth_factor = np.exp(fit_results.params[0])
+
+        return {'fit_type': 'Exponential',
+                'fit_results': fit_results,
+                'growth_factor': growth_factor}
+
+
+class GrowthFactorWADTLin(GrowthFactorBase):
+
+    _fit_type = 'WADTLin'
+
+    @staticmethod
+    def linear_rate_fit(week, wadt):
+        r"""OLS regression to estimate the linear growth rate in a single year.
+
+        Parameters
+        ----------
+        week : numpy.ndarray
+            Array of year values.
+        aadt : pandas.DataFrame
+            Array of AADT values.
+        ref_vals : dict containing 'year' and 'aadt' entries.
+            Reference values for normalization.
+
+        Returns
+        -------
+        r : statsmodels.regression.linear_model.RegressionResultsWrapper
+            Fit results.
+
+        Notes
+        -----
+        ADT for week :math:`t`, :math:`A_\mathrm{t}` is assumed to follow
+
+        ..math::
+            A_\mathrm{t} = r(t - t_0) + A_{t_0}
+
+        Where :math:`A_{t_0}` is ADT for a reference year and :math:`r` the
+        growth rate in units of :math:`A / week`.
+
+        """
+        model = sm.OLS(endog=wadt, exog=sm.add_constant(week))
+        return model.fit()
+
+    def fit_growth(self, tc):
+        # Process week vs. weekly averaged ADT.
+        wadt = self.get_wadt(tc)
+        fit_results = self.linear_rate_fit(wadt['Week'].values,
+                                           wadt['WADT'].values)
+
+        # Convert linear weekly fit to yearly exponential fit (iffy logic).
+        aadt_info = tc.data['AADT'].reset_index()
+        growth_factor = 1. + (fit_results[1] * 52. /
+                              aadt_info['AADT'].values[0])
+
+        return {'fit_type': 'Linear',
+                'fit_results': fit_results,
+                'growth_factor': growth_factor}
+
+
+class GrowthFactorComposite(GrowthFactorBase):
+    # Not inheriting from GrowthFactorAADTExp and WADTLin because we need to
+    # resolve two versions of `fit_growth`.
+
+    _fit_type = 'Composite'
+
+    def __init__(self):
+        self.aadt_exp = GrowthFactorAADTExp()
+        self.wadt_lin = GrowthFactorWADTLin()
+
+    def fit_growth(self, tc):
+        if len(tc.data['AADT'].shape[0]) > 1:
+            return self.aadt_exp.fit_growth(tc)
+        return self.wadt_lin.fit_growth(tc)

--- a/traffic_prophet/countmatch/growthfactor.py
+++ b/traffic_prophet/countmatch/growthfactor.py
@@ -132,9 +132,9 @@ class GrowthFactorAADTExp(GrowthFactorBase):
             {'year': aadt.at[0, 'Year'], 'aadt': aadt.at[0, 'AADT']})
         growth_factor = np.exp(fit_results.params[0])
 
-        return {'fit_type': 'Exponential',
-                'fit_results': fit_results,
-                'growth_factor': growth_factor}
+        tc._growth_fit = {'fit_type': 'Exponential',
+                          'fit_results': fit_results,
+                          'growth_factor': growth_factor}
 
 
 class GrowthFactorWADTLin(GrowthFactorBase):
@@ -185,9 +185,9 @@ class GrowthFactorWADTLin(GrowthFactorBase):
         growth_factor = 1. + (fit_results.params[1] * 52. /
                               tc.adts['AADT']['AADT'].values[0])
 
-        return {'fit_type': 'Linear',
-                'fit_results': fit_results,
-                'growth_factor': growth_factor}
+        tc._growth_fit = {'fit_type': 'Linear',
+                          'fit_results': fit_results,
+                          'growth_factor': growth_factor}
 
 
 class GrowthFactorComposite(GrowthFactorBase):
@@ -202,5 +202,6 @@ class GrowthFactorComposite(GrowthFactorBase):
 
     def fit_growth(self, tc):
         if tc.adts['AADT'].shape[0] > 1:
-            return self.aadt_exp.fit_growth(tc)
-        return self.wadt_lin.fit_growth(tc)
+            self.aadt_exp.fit_growth(tc)
+        else:
+            self.wadt_lin.fit_growth(tc)

--- a/traffic_prophet/countmatch/growthfactor.py
+++ b/traffic_prophet/countmatch/growthfactor.py
@@ -14,6 +14,7 @@ class GFRegistrar(type):
     See https://github.com/mhvk/baseband.
 
     """
+
     _registry = GF_REGISTRY
 
     def __init__(cls, name, bases, dct):
@@ -23,7 +24,7 @@ class GFRegistrar(type):
             if not hasattr(cls, "_fit_type"):
                 raise ValueError("must define a `_fit_type`.")
             elif cls._fit_type in GFRegistrar._registry:
-                raise ValueError("EDV {0} already registered in "
+                raise ValueError("name {0} already registered in "
                                  "GF_REGISTRY".format(cls._fit_type))
 
             GFRegistrar._registry[cls._fit_type] = cls
@@ -35,8 +36,6 @@ class GrowthFactor:
 
     def __new__(cls, proctype, *args, **kwargs):
         # __init__ has to be called manually!
-        # https://docs.python.org/3/reference/datamodel.html#object.__new__
-        # https://stackoverflow.com/questions/20221858/python-new-method-returning-something-other-than-class-instance
         self = super().__new__(GF_REGISTRY[proctype])
         self.__init__(*args, **kwargs)
         return self
@@ -176,7 +175,7 @@ class GrowthFactorWADTLin(GrowthFactorBase):
 
         # Convert linear weekly fit to yearly exponential fit (iffy logic).
         aadt_info = tc.data['AADT'].reset_index()
-        growth_factor = 1. + (fit_results[1] * 52. /
+        growth_factor = 1. + (fit_results.params[1] * 52. /
                               aadt_info['AADT'].values[0])
 
         return {'fit_type': 'Linear',
@@ -195,6 +194,6 @@ class GrowthFactorComposite(GrowthFactorBase):
         self.wadt_lin = GrowthFactorWADTLin()
 
     def fit_growth(self, tc):
-        if len(tc.data['AADT'].shape[0]) > 1:
+        if tc.data['AADT'].shape[0] > 1:
             return self.aadt_exp.fit_growth(tc)
         return self.wadt_lin.fit_growth(tc)

--- a/traffic_prophet/countmatch/permcount.py
+++ b/traffic_prophet/countmatch/permcount.py
@@ -30,11 +30,20 @@ class PermCount(base.Count):
                  perm_years):
         super().__init__(count_id, centreline_id, direction, data,
                          is_permanent=True)
+        if len(perm_years) == 0:
+            raise ValueError("cannot have empty perm_years!")
         self._perm_years = perm_years
+        self._growth_fit = None
 
     @property
     def perm_years(self):
         return self._perm_years
+
+    @property
+    def growth_factor(self):
+        if self._growth_fit is None:
+            raise AttributeError("PTC has not had its growth factor fit!")
+        return self._growth_fit['growth_factor']
 
     @classmethod
     def from_count_object(cls, tc, perm_years):

--- a/traffic_prophet/countmatch/permcount.py
+++ b/traffic_prophet/countmatch/permcount.py
@@ -24,20 +24,17 @@ class PermCount(base.Count):
         Raw daily traffic counts.
     perm_years : list
         List of years to use as permanent count.
-    dv_processor : DerivedVal instance
-        For imputation and derived properties.
-    growth_factor : GrowthFactor instance
-        For estimating growth factor.
-    process: bool
-        Process PTC for derived properties and growth rate.  Default: `True`.
     """
 
     def __init__(self, count_id, centreline_id, direction, data,
                  perm_years):
-        data = {'Daily Count': data}
         super().__init__(count_id, centreline_id, direction, data,
                          is_permanent=True)
-        self.perm_years = perm_years
+        self._perm_years = perm_years
+
+    @property
+    def perm_years(self):
+        return self._perm_years
 
     @classmethod
     def from_count_object(cls, tc, perm_years):
@@ -51,6 +48,15 @@ class PermCountProcessor:
     Currently a permanent count needs to have at least one year with all 12
     months and a sufficient number of total days represented, not be from HW401
     and not be excluded by the user in the config file.
+
+    Parameters
+    ----------
+    dv_calc : DerivedVal instance
+        For imputation and derived properties.
+    gf_calc : GrowthFactor instance
+        For estimating growth factor.
+    cfg : dict, optional
+        Configuration settings.  Default: `config.cm`.
     """
 
     def __init__(self, dv_calc, gf_calc, cfg=cfg.cm):
@@ -100,8 +106,8 @@ class PermCountProcessor:
             raise ValueError("no count file has sufficient data to use in "
                              "the model!  Check configuration settings.")
         elif not len(tcs.ptcs):
-            warnings.warn(
-                "no permanent counts read!  Check configuration settings.")
+            warnings.warn("no permanent counts read!  "
+                          "Check configuration settings.")
         elif not len(tcs.sttcs):
             warnings.warn("file only contains permanent counts!")
 

--- a/traffic_prophet/countmatch/permcount.py
+++ b/traffic_prophet/countmatch/permcount.py
@@ -1,0 +1,111 @@
+"""Determine permanent count year-on-year growth factors."""
+
+import numpy as np
+import statsmodels.api as sm
+
+from . import reader
+from . import growthfactor as gf
+from .. import cfg
+
+
+class PermCount(reader.Count):
+    """Class to hold permanent count data and calculate growth factors.
+
+    Parameters
+    ----------
+    count_id : int
+        ID of count.
+    centreline_id : int
+        Centreline ID associated with count.
+    direction : +1 or -1
+        Direction of traffic travel.
+    data : pandas.DataFrame
+        Raw daily traffic counts.
+    perm_years : list
+        List of years to use as permanent count.
+    dv_processor : DerivedVal instance
+        For imputation and derived properties.
+    growth_factor : GrowthFactor instance
+        For estimating growth factor.
+    process: bool
+        Process PTC for derived properties and growth rate.  Default: `True`.
+    """
+
+    def __init__(self, count_id, centreline_id, direction, data,
+                 perm_years):
+        data = {'Daily Count': data}
+        super().__init__(count_id, centreline_id, direction, data,
+                         is_permanent=True)
+        self.perm_info = perm_years
+
+    @classmethod
+    def from_count_object(cls, tc, perm_years):
+        return cls(tc.count_id, tc.centreline_id, tc.direction, tc.data,
+                   perm_years)
+
+
+class PermCountProcessor:
+    """Class for processing a list of counts into PTCs and STTCs.
+
+    Currently a permanent count needs to have at least one year with all 12
+    months and a sufficient number of total days represented, not be from HW401
+    and not be excluded by the user in the config file.
+    """
+
+    def __init__(self, dv_calc, gf_calc, cfg=cfg.cm):
+        self.dvc = dv_calc
+        self.gfc = gf_calc
+        self.cfg = cfg
+        # Obtain a list of count_ids that (according to TEPs-I) should not be
+        # PTCs because they reduce the accuracy of CountMatch.
+        self.excluded_ids = (self.cfg['exclude_ptc_pos'] +
+                             [-id for id in self.cfg['exclude_ptc_neg']])
+
+    def partition_years(self, tc):
+        """Partition data by year, and determine when `tc` is a PTC.
+
+        Determines which years of a count satisfy the TEPs permanent count
+        requirements.
+
+        Parameters
+        ----------
+        rd : reader.Count
+            Candidate for permanent traffic count.
+
+        Returns
+        -------
+        perm_years : list
+            List of years that satisfy permanent count requirements.
+        """
+        # If count location on exclusion list, it's not a PTC.
+        if tc.count_id in self.excluded_ids:
+            return []
+
+        # Get number of days and months in each year.
+        mg = tc.data['Date'].dt.month.groupby(level=[0, ])
+        counts_per_year = mg.count()
+        n_unique_months = mg.apply(lambda x: x.unique().shape[0])
+
+        perm_years = counts_per_year[
+            (n_unique_months >= self.cfg['min_permanent_months']) &
+            (counts_per_year >= self.cfg['min_permanent_days'])].index.values
+
+        return perm_years
+
+    def get_ptcs_sttcs(self, tcs):
+        for tc in tcs.counts:
+            perm_years = self.partition_years(tc)
+            if len(perm_years):
+                tcs.ptcs[tc.count_id] = (
+                    PermCount.from_count_object(tc, perm_years))
+                self.dvc.calculate(tc.ptcs[tc.count_id])
+                self.gfc.fit_growth(tc.ptcs[tc.count_id])
+            else:
+                tcs.sttcs[tc.count_id] = tc
+
+
+def get_ptcs_sttcs(tcs):
+    dv_calc = SOME STUFF
+    gf_calc = SOME STUFF
+    ptcproc = PermCountProcessor(dv_calc, gf_calc)
+    ptcproc.get_ptcs_sttcs(tcs)

--- a/traffic_prophet/countmatch/permcount.py
+++ b/traffic_prophet/countmatch/permcount.py
@@ -37,10 +37,12 @@ class PermCount(base.Count):
 
     @property
     def perm_years(self):
+        """List of years where the count is permanent."""
         return self._perm_years
 
     @property
     def growth_factor(self):
+        """Multiplicative year-on-year growth factor."""
         if self._growth_fit is None:
             raise AttributeError("PTC has not had its growth factor fit!")
         return self._growth_fit['growth_factor']
@@ -63,7 +65,7 @@ class PermCountProcessor:
     dv_calc : DerivedVal instance
         For imputation and derived properties.
     gf_calc : GrowthFactor instance
-        For estimating growth factor.
+        For estimating the growth factor.
     cfg : dict, optional
         Configuration settings.  Default: `config.cm`.
     """
@@ -72,8 +74,7 @@ class PermCountProcessor:
         self.dvc = dv_calc
         self.gfc = gf_calc
         self.cfg = cfg
-        # Obtain a list of count_ids that (according to TEPs-I) should not be
-        # PTCs because they reduce the accuracy of CountMatch.
+        # Obtain a list of count_ids that should be excluded from being PTCs.
         self.excluded_ids = (self.cfg['exclude_ptc_pos'] +
                              [-id for id in self.cfg['exclude_ptc_neg']])
         self._disable_tqdm = not self.cfg['verbose']

--- a/traffic_prophet/countmatch/reader.py
+++ b/traffic_prophet/countmatch/reader.py
@@ -47,11 +47,11 @@ class RawAnnualCount(Count):
 
 class ReaderBase:
 
-    def __init__(self, source, cfgcm=cfg.cm):
+    def __init__(self, source, cfg=cfg.cm):
         # Store permanent and temporary stations.
         self.counts = None
         self.source = source
-        self.cfg = cfgcm
+        self.cfg = cfg
 
     def read(self):
         """Read source data into a dictionary of counts."""
@@ -68,7 +68,7 @@ class ReaderBase:
 
     def has_enough_data(self, data):
         """Checks if there is enough data to be a usable count."""
-        return data.shape[0] >= self.cfg['min_stn_count']
+        return data.shape[0] >= self.cfg['min_count']
 
     @staticmethod
     def reset_daily_count_index(daily_count):
@@ -107,14 +107,14 @@ class ReaderBase:
 
 class ReaderZip(ReaderBase):
 
-    def __init__(self, source, cfgcm=cfg.cm):
+    def __init__(self, source, cfg=cfg.cm):
         if type(source) == str:
             source = glob.glob(source)
         elif type(source) == dict:
             source = [source[k] for k in sorted(source.keys())]
         source = sorted(source)
 
-        super().__init__(source, cfgcm=cfgcm)
+        super().__init__(source, cfg=cfg)
 
     def read_source(self, counts):
         """Read zip file contents into RawAnnualCount objects."""

--- a/traffic_prophet/countmatch/reader.py
+++ b/traffic_prophet/countmatch/reader.py
@@ -232,7 +232,7 @@ class ReaderPostgres(ReaderBase):
 
     def preprocess_count_data(self, rd):
         """Minor preprocessing of raw count data."""
-        # Not idempotent.
+        # `reset_daily_count_index` alters rd.
         self.reset_daily_count_index(rd['data'])
         return rd
 
@@ -264,9 +264,10 @@ class ReaderPostgres(ReaderBase):
                        'year': year}
 
 
-def read(source):
-    rdr = (ReaderPostgres(source) if isinstance(source, conn.Connection)
-           else ReaderZip(source))
+def read(source, cfg=cfg.cm):
+    rdr = (ReaderPostgres(source, cfg=cfg)
+           if isinstance(source, conn.Connection)
+           else ReaderZip(source, cfg=cfg))
     rdr.read()
 
     return rdr

--- a/traffic_prophet/countmatch/reader.py
+++ b/traffic_prophet/countmatch/reader.py
@@ -5,22 +5,12 @@ import pandas as pd
 import zipfile
 import glob
 
+from . import base
 from .. import cfg
 from .. import conn
 
 
-class Count:
-
-    def __init__(self, count_id, centreline_id, direction,
-                 data, is_permanent=False):
-        self.count_id = count_id
-        self.centreline_id = int(centreline_id)
-        self.direction = int(direction)
-        self.is_permanent = bool(is_permanent)
-        self.data = data
-
-
-class RawAnnualCount(Count):
+class RawAnnualCount(base.Count):
     """Storage for raw daily traffic for one year."""
 
     def __init__(self, count_id, centreline_id, direction, year,
@@ -99,10 +89,10 @@ class ReaderBase:
                     [[item.year, ], _ctable.index],
                     names=['Year', _ctable.index.name])
             unified_data = pd.concat([c.data for c in counts[cid]])
-            counts[cid] = Count(counts[cid][0].count_id,
-                                counts[cid][0].centreline_id,
-                                counts[cid][0].direction,
-                                unified_data, is_permanent=False)
+            counts[cid] = base.Count(counts[cid][0].count_id,
+                                     counts[cid][0].centreline_id,
+                                     counts[cid][0].direction,
+                                     unified_data, is_permanent=False)
 
 
 class ReaderZip(ReaderBase):

--- a/traffic_prophet/countmatch/tests/conftest.py
+++ b/traffic_prophet/countmatch/tests/conftest.py
@@ -1,6 +1,6 @@
 """CountMatch test suite preprocessing.
 
-Fixtures used by multiple files in this and subdirectories must be placed here.
+Fixtures used by multiple files in this and subdirectories are placed here.
 See https://docs.pytest.org/en/latest/fixture.html#conftest-py-sharing-fixture-functions
 for more.
 

--- a/traffic_prophet/countmatch/tests/conftest.py
+++ b/traffic_prophet/countmatch/tests/conftest.py
@@ -22,7 +22,7 @@ def cfgcm_test():
         'min_counts_in_day': 24,
         'min_permanent_months': 12,
         'min_permanent_days': 274,
-        'exclude_ptc_neg': [],
+        'exclude_ptc_neg': [446378, ],
         'exclude_ptc_pos': [],
         'derived_vals_calculator': 'Standard',
         'derived_vals_settings': {},

--- a/traffic_prophet/countmatch/tests/conftest.py
+++ b/traffic_prophet/countmatch/tests/conftest.py
@@ -1,0 +1,38 @@
+"""CountMatch test suite preprocessing.
+
+Fixtures used by multiple files in this and subdirectories must be placed here.
+See https://docs.pytest.org/en/latest/fixture.html#conftest-py-sharing-fixture-functions
+for more.
+
+"""
+
+import pytest
+
+from .. import reader
+
+from ...data import SAMPLE_ZIP
+
+
+@pytest.fixture(scope="session")
+def cfgcm_test():
+    # Configuration settings for tests.
+    return {
+        'verbose': False,
+        'min_count': 96,
+        'min_counts_in_day': 24,
+        'min_permanent_months': 12,
+        'min_permanent_days': 274,
+        'exclude_ptc_neg': [],
+        'exclude_ptc_pos': [],
+        'derived_vals_calculator': 'Standard',
+        'derived_vals_settings': {},
+        'growth_factor_calculator': 'Composite',
+        'growth_factor_settings': {},
+        'min_year': 2006,
+        'max_year': 2018
+    }
+
+
+@pytest.fixture(scope="session")
+def sample_counts(cfgcm_test):
+    return reader.read(SAMPLE_ZIP, cfg=cfgcm_test)

--- a/traffic_prophet/countmatch/tests/test_base.py
+++ b/traffic_prophet/countmatch/tests/test_base.py
@@ -1,3 +1,5 @@
+import operator
+
 from .. import base
 
 
@@ -7,6 +9,6 @@ class TestCount:
         count = base.Count('test', 1, -1., None)
         assert count.count_id == 'test'
         assert count.centreline_id == 1
-        assert count.direction == -1
+        assert operator.index(count.direction) == -1
         assert count.data is None
         assert not count.is_permanent

--- a/traffic_prophet/countmatch/tests/test_base.py
+++ b/traffic_prophet/countmatch/tests/test_base.py
@@ -1,14 +1,18 @@
-import pytest
-import hypothesis
-
-import numpy as np
-import pandas as pd
-import datetime
-
-from ...data import SAMPLE_ZIP
-from .. import reader
+from .. import base
 
 
-@pytest.fixture(scope="module", autouse=True)
-def counts():
-    return reader.read_zip(SAMPLE_ZIP)
+# from ...data import SAMPLE_ZIP
+# @pytest.fixture(scope="module", autouse=True)
+# def counts():
+#     return reader.read(SAMPLE_ZIP)
+
+
+class TestCount:
+
+    def test_count(self):
+        count = base.Count('test', 1, -1., None)
+        assert count.count_id == 'test'
+        assert count.centreline_id == 1
+        assert count.direction == -1
+        assert count.data is None
+        assert not count.is_permanent

--- a/traffic_prophet/countmatch/tests/test_base.py
+++ b/traffic_prophet/countmatch/tests/test_base.py
@@ -1,12 +1,6 @@
 from .. import base
 
 
-# from ...data import SAMPLE_ZIP
-# @pytest.fixture(scope="module", autouse=True)
-# def counts():
-#     return reader.read(SAMPLE_ZIP)
-
-
 class TestCount:
 
     def test_count(self):

--- a/traffic_prophet/countmatch/tests/test_derivedvals.py
+++ b/traffic_prophet/countmatch/tests/test_derivedvals.py
@@ -1,0 +1,144 @@
+import pytest
+import hypothesis as hyp
+import numpy as np
+import pandas as pd
+
+from .. import permcount as pc
+from .. import derivedvals as dv
+
+
+def get_single_ptc(sample_counts, cfgcm_test, count_id):
+    pcpp = pc.PermCountProcessor(None, None, cfg=cfgcm_test)
+    perm_years = pcpp.partition_years(sample_counts.counts[count_id])
+    ptc = pc.PermCount.from_count_object(sample_counts.counts[count_id],
+                                         perm_years)
+    return ptc
+
+
+@pytest.fixture(scope='module')
+def ptc_oneyear(sample_counts, cfgcm_test):
+    return get_single_ptc(sample_counts, cfgcm_test, -890)
+
+
+@pytest.fixture(scope='module')
+def ptc_multiyear(sample_counts, cfgcm_test):
+    return get_single_ptc(sample_counts, cfgcm_test, -104870)
+
+
+class TestDerivedValsBase:
+
+    def setup(self):
+        self.dvc = dv.DerivedValsBase()
+
+    def test_preprocess_daily_counts(self, ptc_multiyear):
+        dca = self.dvc.preprocess_daily_counts(ptc_multiyear.data)
+        assert 'Month' in dca.columns
+        assert 'Day of Week' in dca.columns
+
+    def test_get_madt(self, ptc_oneyear, ptc_multiyear):
+        for ptc in (ptc_oneyear, ptc_multiyear):
+            dca = self.dvc.preprocess_daily_counts(ptc.data)
+            madt = self.dvc.get_madt(dca)
+
+            madt_ref = pd.DataFrame({
+                'MADT': dca.groupby(['Year', 'Month'])['Daily Count'].mean(),
+                'Days Available': dca.groupby(
+                    ['Year', 'Month'])['Daily Count'].count()},
+                index=pd.MultiIndex.from_product(
+                    [dca.index.levels[0], np.arange(1, 13, dtype=int)],
+                    names=['Year', 'Month']))
+            madt_ref['Days in Month'] = [
+                pd.to_datetime("{0}-{1}-01".format(*idxs)).daysinmonth
+                for idxs in madt_ref.index]
+
+            assert np.allclose(madt['MADT'], madt_ref['MADT'], rtol=1e-10,
+                               equal_nan=True)
+            assert np.allclose(madt['Days Available'],
+                               madt_ref['Days Available'], rtol=1e-10,
+                               equal_nan=True)
+            assert np.allclose(madt['Days in Month'],
+                               madt_ref['Days in Month'], rtol=1e-10,
+                               equal_nan=True)
+
+            # None of the sample data are for leap years.
+            assert (madt['Days in Month'].sum() //
+                    len(dca.index.levels[0])) == 365
+
+    def test_get_aadt_py_from_madt(self, ptc_oneyear, ptc_multiyear):
+        for ptc in (ptc_oneyear, ptc_multiyear):
+            madt = self.dvc.get_madt(
+                self.dvc.preprocess_daily_counts(ptc.data))
+            aadt = self.dvc.get_aadt_py_from_madt(madt, ptc.perm_years)
+
+            madt_py = madt.loc[ptc.perm_years, :].copy()
+            madt_py['Weighted MADT'] = (madt_py['MADT'] *
+                                        madt_py['Days in Month'])
+            madtg = madt_py.groupby('Year')
+            aadt_ref = (madtg['Weighted MADT'].sum() /
+                        madtg['Days in Month'].sum())
+
+            assert np.allclose(aadt['AADT'], aadt_ref, rtol=1e-10)
+
+    def test_get_ratios_py(self, ptc_oneyear, ptc_multiyear):
+        for ptc in (ptc_oneyear, ptc_multiyear):
+            dca = self.dvc.preprocess_daily_counts(ptc.data)
+            madt = self.dvc.get_madt(dca)
+            aadt = self.dvc.get_aadt_py_from_madt(madt, ptc.perm_years)
+            dom_ijd, d_ijd, n_avail_days = (
+                self.dvc.get_ratios_py(dca, madt, aadt, ptc.perm_years))
+
+            dc_dom = (dca.loc[ptc.perm_years]
+                      .groupby(['Year', 'Month', 'Day of Week']))
+            domadt = (dc_dom['Daily Count'].mean()
+                      .unstack(level=-1, fill_value=np.nan))
+            n_avail_days_ref = (dc_dom['Daily Count'].count()
+                                .unstack(level=-1, fill_value=np.nan))
+
+            assert np.allclose(n_avail_days, n_avail_days_ref,
+                               rtol=1e-10, equal_nan=True)
+
+            # Test if we can recover MADT from `domadt` and `dom_ijd`
+            madt_pym = np.repeat(madt.loc[ptc.perm_years, 'MADT']
+                                 .values[:, np.newaxis], 7, axis=1)
+            madt_pym_est = (domadt * dom_ijd).values
+            assert np.allclose(madt_pym_est[~np.isnan(madt_pym_est)],
+                               madt_pym[~np.isnan(madt_pym_est)],
+                               rtol=1e-10)
+
+            # Test if we can recover AADT from `domadt` and `d_ijd`.
+            aadt_pym = np.repeat(aadt['AADT']
+                                 .values[:, np.newaxis], 7 * 12, axis=1)
+            aadt_pym_est = (domadt * d_ijd).unstack(level=-1).values
+            assert np.allclose(aadt_pym_est[~np.isnan(aadt_pym_est)],
+                               aadt_pym[~np.isnan(aadt_pym_est)],
+                               rtol=1e-10)
+
+
+class TestDerivedValsStandard:
+
+    def setup(self):
+        self.dvc = dv.DerivedValsStandard()
+
+    def test_get_derived_vals(self, sample_counts, cfgcm_test):
+        ptc_oneyear = get_single_ptc(sample_counts, cfgcm_test, -890)
+        ptc_multiyear = get_single_ptc(sample_counts, cfgcm_test, -104870)
+
+        for ptc in (ptc_oneyear, ptc_multiyear):
+            self.dvc.get_derived_vals(ptc)
+            assert 'MADT' in ptc.adts.keys()
+            assert 'AADT' in ptc.adts.keys()
+            assert 'DoM_ijd' in ptc.ratios.keys()
+            assert 'D_ijd' in ptc.ratios.keys()
+            assert 'N_avail_days' in ptc.ratios.keys()
+
+    def test_imputer(self, sample_counts, cfgcm_test):
+        ptc_multiyear = get_single_ptc(sample_counts, cfgcm_test, -104870)
+
+
+class TestDerivedVals:
+
+    def test_derivedvals(self):
+        dvc = dv.DerivedVals('Standard')
+        assert isinstance(dvc, dv.DerivedValsStandard)
+        with pytest.raises(KeyError):
+            dvc = dv.DerivedVals('Something')

--- a/traffic_prophet/countmatch/tests/test_derivedvals.py
+++ b/traffic_prophet/countmatch/tests/test_derivedvals.py
@@ -132,7 +132,7 @@ class TestDerivedValsStandard:
             assert 'N_avail_days' in ptc.ratios.keys()
 
     def test_imputer(self, sample_counts, cfgcm_test):
-        ptc_multiyear = get_single_ptc(sample_counts, cfgcm_test, -104870)
+        pass
 
 
 class TestDerivedVals:

--- a/traffic_prophet/countmatch/tests/test_derivedvals.py
+++ b/traffic_prophet/countmatch/tests/test_derivedvals.py
@@ -1,5 +1,4 @@
 import pytest
-import hypothesis as hyp
 import numpy as np
 import pandas as pd
 
@@ -7,111 +6,135 @@ from .. import permcount as pc
 from .. import derivedvals as dv
 
 
-def get_single_ptc(sample_counts, cfgcm_test, count_id):
-    pcpp = pc.PermCountProcessor(None, None, cfg=cfgcm_test)
-    perm_years = pcpp.partition_years(sample_counts.counts[count_id])
-    ptc = pc.PermCount.from_count_object(sample_counts.counts[count_id],
-                                         perm_years)
+def get_single_ptc(counts, cfgcm, count_id):
+    pcpp = pc.PermCountProcessor(None, None, cfg=cfgcm)
+    perm_years = pcpp.partition_years(counts.counts[count_id])
+    ptc = pc.PermCount.from_count_object(counts.counts[count_id], perm_years)
     return ptc
 
 
-@pytest.fixture(scope='module')
-def ptc_oneyear(sample_counts, cfgcm_test):
-    return get_single_ptc(sample_counts, cfgcm_test, -890)
+class TestDVRegistrarDerivedVals:
+    """Tests DVRegistrar and DerivedVals."""
 
+    def test_dvregistrar(self):
 
-@pytest.fixture(scope='module')
-def ptc_multiyear(sample_counts, cfgcm_test):
-    return get_single_ptc(sample_counts, cfgcm_test, -104870)
+        # Test successful initialization of DerivedVals subclass.
+        class DerivedValsStandardTest(dv.DerivedValsStandard):
+            _dv_type = 'Testing'
+
+        assert dv.DV_REGISTRY['Testing'] is DerivedValsStandardTest
+        dv_instance = dv.DerivedVals('Testing')
+        assert dv_instance._dv_type == 'Testing'
+
+        # Pop the dummy class, in case we test twice.
+        dv.DVRegistrar._registry.pop('Testing', None)
+
+        # Test repeated `_dv_type` error handling.
+        with pytest.raises(ValueError) as excinfo:
+            class DerivedValsStandardBad1(dv.DerivedValsStandard):
+                pass
+        assert "already registered in" in str(excinfo.value)
+
+        # Test missing `_dv_type` error handling.
+        with pytest.raises(ValueError) as excinfo:
+            class DerivedValsStandardBad2(dv.DerivedValsBase):
+                pass
+        assert "must define a" in str(excinfo.value)
 
 
 class TestDerivedValsBase:
 
+    @pytest.fixture(params=[-890, -104870])
+    def ptc_sample(self, sample_counts, cfgcm_test, request):
+        return get_single_ptc(sample_counts, cfgcm_test, request.param)
+
     def setup(self):
         self.dvc = dv.DerivedValsBase()
 
-    def test_preprocess_daily_counts(self, ptc_multiyear):
-        dca = self.dvc.preprocess_daily_counts(ptc_multiyear.data)
-        assert 'Month' in dca.columns
-        assert 'Day of Week' in dca.columns
+    def test_preprocess_daily_counts(self, ptc_sample):
+        dca = self.dvc.preprocess_daily_counts(ptc_sample.data)
+        assert np.array_equal(dca['Month'], ptc_sample.data['Date'].dt.month)
+        assert np.array_equal(dca['Day of Week'],
+                              ptc_sample.data['Date'].dt.dayofweek)
 
-    def test_get_madt(self, ptc_oneyear, ptc_multiyear):
-        for ptc in (ptc_oneyear, ptc_multiyear):
-            dca = self.dvc.preprocess_daily_counts(ptc.data)
-            madt = self.dvc.get_madt(dca)
+    def test_get_madt(self, ptc_sample):
+        dca = self.dvc.preprocess_daily_counts(ptc_sample.data)
+        madt = self.dvc.get_madt(dca)
 
-            madt_ref = pd.DataFrame({
-                'MADT': dca.groupby(['Year', 'Month'])['Daily Count'].mean(),
-                'Days Available': dca.groupby(
-                    ['Year', 'Month'])['Daily Count'].count()},
-                index=pd.MultiIndex.from_product(
-                    [dca.index.levels[0], np.arange(1, 13, dtype=int)],
-                    names=['Year', 'Month']))
-            madt_ref['Days in Month'] = [
-                pd.to_datetime("{0}-{1}-01".format(*idxs)).daysinmonth
-                for idxs in madt_ref.index]
+        madt_ref = pd.DataFrame({
+            'MADT': dca.groupby(['Year', 'Month'])['Daily Count'].mean(),
+            'Days Available': dca.groupby(
+                ['Year', 'Month'])['Daily Count'].count()},
+            index=pd.MultiIndex.from_product(
+                [dca.index.levels[0], np.arange(1, 13, dtype=int)],
+                names=['Year', 'Month']))
+        madt_ref['Days in Month'] = [
+            pd.to_datetime("{0}-{1}-01".format(*idxs)).daysinmonth
+            for idxs in madt_ref.index]
 
-            assert np.allclose(madt['MADT'], madt_ref['MADT'], rtol=1e-10,
-                               equal_nan=True)
-            assert np.allclose(madt['Days Available'],
-                               madt_ref['Days Available'], rtol=1e-10,
-                               equal_nan=True)
-            assert np.allclose(madt['Days in Month'],
-                               madt_ref['Days in Month'], rtol=1e-10,
-                               equal_nan=True)
+        tols = {'rtol': 1e-10, 'equal_nan': True}
+        assert np.allclose(madt['MADT'], madt_ref['MADT'], **tols)
+        assert np.allclose(madt['Days Available'],
+                           madt_ref['Days Available'], **tols)
+        assert np.allclose(madt['Days in Month'],
+                           madt_ref['Days in Month'], **tols)
 
-            # None of the sample data are for leap years.
-            assert (madt['Days in Month'].sum() //
-                    len(dca.index.levels[0])) == 365
+        # None of the sample data are for leap years.
+        assert (madt['Days in Month'].sum() //
+                len(dca.index.levels[0])) == 365
+        assert (madt['Days in Month'].sum() % len(dca.index.levels[0])) == (
+            1 if 2012 in dca.index.levels[0] else 0)
 
-    def test_get_aadt_py_from_madt(self, ptc_oneyear, ptc_multiyear):
-        for ptc in (ptc_oneyear, ptc_multiyear):
-            madt = self.dvc.get_madt(
-                self.dvc.preprocess_daily_counts(ptc.data))
-            aadt = self.dvc.get_aadt_py_from_madt(madt, ptc.perm_years)
+    def test_get_aadt_py_from_madt(self, ptc_sample):
+        madt = self.dvc.get_madt(
+            self.dvc.preprocess_daily_counts(ptc_sample.data))
+        aadt = self.dvc.get_aadt_py_from_madt(madt, ptc_sample.perm_years)
 
-            madt_py = madt.loc[ptc.perm_years, :].copy()
-            madt_py['Weighted MADT'] = (madt_py['MADT'] *
-                                        madt_py['Days in Month'])
-            madtg = madt_py.groupby('Year')
-            aadt_ref = (madtg['Weighted MADT'].sum() /
-                        madtg['Days in Month'].sum())
+        madt_py = madt.loc[ptc_sample.perm_years, :].copy()
+        madt_py['Weighted MADT'] = (madt_py['MADT'] *
+                                    madt_py['Days in Month'])
+        madtg = madt_py.groupby('Year')
+        aadt_ref = (madtg['Weighted MADT'].sum() /
+                    madtg['Days in Month'].sum())
 
-            assert np.allclose(aadt['AADT'], aadt_ref, rtol=1e-10)
+        assert np.allclose(aadt['AADT'], aadt_ref, rtol=1e-10)
 
-    def test_get_ratios_py(self, ptc_oneyear, ptc_multiyear):
-        for ptc in (ptc_oneyear, ptc_multiyear):
-            dca = self.dvc.preprocess_daily_counts(ptc.data)
-            madt = self.dvc.get_madt(dca)
-            aadt = self.dvc.get_aadt_py_from_madt(madt, ptc.perm_years)
-            dom_ijd, d_ijd, n_avail_days = (
-                self.dvc.get_ratios_py(dca, madt, aadt, ptc.perm_years))
+    def test_get_ratios_py(self, ptc_sample):
+        dca = self.dvc.preprocess_daily_counts(ptc_sample.data)
+        madt = self.dvc.get_madt(dca)
+        aadt = self.dvc.get_aadt_py_from_madt(madt, ptc_sample.perm_years)
+        dom_ijd, d_ijd, n_avail_days = (
+            self.dvc.get_ratios_py(dca, madt, aadt, ptc_sample.perm_years))
 
-            dc_dom = (dca.loc[ptc.perm_years]
-                      .groupby(['Year', 'Month', 'Day of Week']))
-            domadt = (dc_dom['Daily Count'].mean()
-                      .unstack(level=-1, fill_value=np.nan))
-            n_avail_days_ref = (dc_dom['Daily Count'].count()
-                                .unstack(level=-1, fill_value=np.nan))
+        dc_dom = (dca.loc[ptc_sample.perm_years]
+                  .groupby(['Year', 'Month', 'Day of Week']))
+        domadt = (dc_dom['Daily Count'].mean()
+                  .unstack(level=-1, fill_value=np.nan))
+        n_avail_days_ref = (dc_dom['Daily Count'].count()
+                            .unstack(level=-1, fill_value=np.nan))
 
-            assert np.allclose(n_avail_days, n_avail_days_ref,
-                               rtol=1e-10, equal_nan=True)
+        assert np.allclose(n_avail_days, n_avail_days_ref,
+                           rtol=1e-10, equal_nan=True)
 
-            # Test if we can recover MADT from `domadt` and `dom_ijd`
-            madt_pym = np.repeat(madt.loc[ptc.perm_years, 'MADT']
-                                 .values[:, np.newaxis], 7, axis=1)
-            madt_pym_est = (domadt * dom_ijd).values
-            assert np.allclose(madt_pym_est[~np.isnan(madt_pym_est)],
-                               madt_pym[~np.isnan(madt_pym_est)],
-                               rtol=1e-10)
+        # Test if we can recover MADT from `domadt` and `dom_ijd`.
+        madt_pym = np.repeat(madt.loc[ptc_sample.perm_years, 'MADT']
+                             .values[:, np.newaxis], 7, axis=1)
+        madt_pym_est = (domadt * dom_ijd).values
+        # madt_pym naturally has no NaNs, while madt_pym_est does, so only
+        # compare non-NaN values.
+        assert np.allclose(madt_pym_est[~np.isnan(madt_pym_est)],
+                           madt_pym[~np.isnan(madt_pym_est)],
+                           rtol=1e-10)
 
-            # Test if we can recover AADT from `domadt` and `d_ijd`.
-            aadt_pym = np.repeat(aadt['AADT']
-                                 .values[:, np.newaxis], 7 * 12, axis=1)
-            aadt_pym_est = (domadt * d_ijd).unstack(level=-1).values
-            assert np.allclose(aadt_pym_est[~np.isnan(aadt_pym_est)],
-                               aadt_pym[~np.isnan(aadt_pym_est)],
-                               rtol=1e-10)
+        # Test if we can recover AADT from `domadt` and `d_ijd`.
+        aadt_pym = np.repeat(aadt['AADT']
+                             .values[:, np.newaxis], 7 * 12, axis=1)
+        aadt_pym_est = (domadt * d_ijd).unstack(level=-1).values
+        # aadt_pym naturally has no NaNs, while aadt_pym_est does, so only
+        # compare non-NaN values.
+        assert np.allclose(aadt_pym_est[~np.isnan(aadt_pym_est)],
+                           aadt_pym[~np.isnan(aadt_pym_est)],
+                           rtol=1e-10)
 
 
 class TestDerivedValsStandard:
@@ -119,17 +142,14 @@ class TestDerivedValsStandard:
     def setup(self):
         self.dvc = dv.DerivedValsStandard()
 
-    def test_get_derived_vals(self, sample_counts, cfgcm_test):
-        ptc_oneyear = get_single_ptc(sample_counts, cfgcm_test, -890)
-        ptc_multiyear = get_single_ptc(sample_counts, cfgcm_test, -104870)
+    @pytest.mark.parametrize('count_id', [-890, -104870])
+    def test_get_derived_vals(self, sample_counts, cfgcm_test, count_id):
+        ptc = get_single_ptc(sample_counts, cfgcm_test, count_id)
 
-        for ptc in (ptc_oneyear, ptc_multiyear):
-            self.dvc.get_derived_vals(ptc)
-            assert 'MADT' in ptc.adts.keys()
-            assert 'AADT' in ptc.adts.keys()
-            assert 'DoM_ijd' in ptc.ratios.keys()
-            assert 'D_ijd' in ptc.ratios.keys()
-            assert 'N_avail_days' in ptc.ratios.keys()
+        self.dvc.get_derived_vals(ptc)
+        assert sorted(list(ptc.adts.keys())) == ['AADT', 'MADT']
+        assert sorted(list(ptc.ratios.keys())) == [
+            'D_ijd', 'DoM_ijd', 'N_avail_days']
 
     def test_imputer(self, sample_counts, cfgcm_test):
         pass

--- a/traffic_prophet/countmatch/tests/test_growthfactor.py
+++ b/traffic_prophet/countmatch/tests/test_growthfactor.py
@@ -9,8 +9,8 @@ from .. import growthfactor as gf
 from ...data import SAMPLE_ZIP
 
 
-class TestGrowthFactor:
-    """Test growth factor calculation."""
+class TestFitters:
+    """Test fitters."""
 
     @hyp.given(slp=hyp.strategies.floats(min_value=-2., max_value=2.))
     @hyp.settings(max_examples=30)
@@ -31,6 +31,10 @@ class TestGrowthFactor:
         y = slp * x + y0
         result = gf.linear_rate_fit(x, y)
         assert np.abs(result.params[1] - slp) < 0.01
+
+
+class TestPermCount:
+    """Test permanent count preprocessing class."""
 
     def test_perm_count(self):
 

--- a/traffic_prophet/countmatch/tests/test_growthfactor.py
+++ b/traffic_prophet/countmatch/tests/test_growthfactor.py
@@ -56,30 +56,25 @@ class TestGrowthFactorBase:
         wadt_nov29 = (ptc_oneyear.data['Daily Count']
                       .loc[(2010, 333):(2010, 339), 'Daily Count'].mean())
         assert np.isclose(
-            (wadt_oy.loc[wadt_oy['Start of Week'] == '2010-06-14', 'WADT']
-             .values[0]), wadt_jun14)
+            wadt_oy.loc[wadt_oy['Week'] == 24, 'WADT'].values[0], wadt_jun14)
         assert np.isclose(
-            (wadt_oy.loc[wadt_oy['Start of Week'] == '2010-11-29', 'WADT']
-             .values[0]), wadt_nov29)
+            wadt_oy.loc[wadt_oy['Week'] == 48, 'WADT'].values[0], wadt_nov29)
 
         # For multiyear PTC, confirm we can reproduce data frame.
         wadt_my = self.gfb.get_wadt_py(ptc_multiyear)
 
-        ptc_multiyear_dc = ptc_multiyear.data['Daily Count'].loc[
-            ptc_multiyear.perm_years, :].copy()
-        ptc_multiyear_dc['Week'] = (
-            ptc_multiyear_dc['Date'] -
-            (ptc_multiyear_dc['Date'].dt.dayofweek *
-             np.timedelta64(1, 'D'))).dt.week
+        wadt_apr26_2010 = (ptc_multiyear.data['Daily Count']
+                           .loc[(2010, 116):(2010, 122), :])
+        wadt_my_apr26_2010 = wadt_my.loc[
+            (wadt_my['Year'] == 2010) & (wadt_my['Week'] == 17), :]
+        assert np.allclose(
+            wadt_my_apr26_2010[['WADT', 'Time']].values.ravel(),
+            np.array([wadt_apr26_2010['Daily Count'].mean(), 17.]))
 
-        wadt_ref = (ptc_multiyear_dc.loc[ptc_multiyear_dc['Week'] < 53, :]
-                    .groupby(['Year', 'Week']).agg(['mean', 'count']))
-        wadt_ref.columns = ('WADT', 'N_days')
-        wadt_ref = wadt_ref.loc[wadt_ref['N_days'] == 7, :].reset_index()
-
-        wadt_ref['Week'] = (wadt_ref['Week'].astype(float) +
-                            52. * (wadt_ref['Year'] - wadt_ref['Year'].min()))
-
-        # Check that all weeks with 7 days are in wadt.
-        assert np.array_equal(wadt_ref['Week'], wadt_my['Week'])
-        assert np.array_equal(wadt_ref['WADT'], wadt_my['WADT'])
+        wadt_oct15_2012 = (ptc_multiyear.data['Daily Count']
+                           .loc[(2012, 289):(2012, 295), :])
+        wadt_my_oct15_2012 = wadt_my.loc[
+            (wadt_my['Year'] == 2012) & (wadt_my['Week'] == 42), :]
+        assert np.allclose(
+            wadt_my_oct15_2012[['WADT', 'Time']].values.ravel(),
+            np.array([wadt_oct15_2012['Daily Count'].mean(), 146.]))

--- a/traffic_prophet/countmatch/tests/test_growthfactor.py
+++ b/traffic_prophet/countmatch/tests/test_growthfactor.py
@@ -1,112 +1,85 @@
+import pytest
 import hypothesis as hyp
 import numpy as np
 import pandas as pd
 import statsmodels.api as sm
 
 from .. import reader
+from .. import permcount as pc
+from .. import derivedvals as dv
 from .. import growthfactor as gf
 
 from ...data import SAMPLE_ZIP
 
 
-class TestFitters:
-    """Test fitters."""
-
-    @hyp.given(slp=hyp.strategies.floats(min_value=-2., max_value=2.))
-    @hyp.settings(max_examples=30)
-    def test_exponential_rate_fit(self, slp):
-        # Create a generic exponential curve.
-        x = np.linspace(1.5, 2.7, 100)
-        y = np.exp(slp * x)
-        result = gf.exponential_rate_fit(x, y,
-                                         {"year": x[0], "aadt": y[0]})
-        assert np.abs(result.params[0] - slp) < 0.01
-
-    @hyp.given(slp=hyp.strategies.floats(min_value=-2., max_value=2.),
-               y0=hyp.strategies.floats(min_value=-2., max_value=2.))
-    @hyp.settings(max_examples=30)
-    def test_linear_rate_fit(self, slp, y0):
-        # Create a generic line.
-        x = np.linspace(0.5, 3.7, 100)
-        y = slp * x + y0
-        result = gf.linear_rate_fit(x, y)
-        assert np.abs(result.params[1] - slp) < 0.01
+def get_single_ptc(sample_counts, cfgcm_test, count_id):
+    pcpp = pc.PermCountProcessor(None, None, cfg=cfgcm_test)
+    perm_years = pcpp.partition_years(sample_counts.counts[count_id])
+    ptc = pc.PermCount.from_count_object(sample_counts.counts[count_id],
+                                         perm_years)
+    dvs = dv.DerivedVals('Standard')
+    dvs.get_derived_vals(ptc)
+    return ptc
 
 
-class TestPermCount:
-    """Test permanent count preprocessing class."""
+@pytest.fixture(scope="module")
+def ptc_oneyear(sample_counts, cfgcm_test):
+    return get_single_ptc(sample_counts, cfgcm_test, -890)
 
-    def test_perm_count(self):
 
-        # Read in data (not doing this at setup since we'll be altering rdr in
-        # another test.
-        rdr = reader.Reader(SAMPLE_ZIP)
-        rdr.read()
+@pytest.fixture(scope="module")
+def ptc_multiyear(sample_counts, cfgcm_test):
+    return get_single_ptc(sample_counts, cfgcm_test, -104870)
 
-        # PTC -104870 has multiple years of data.
-        ptc_raw = rdr.ptcs[-104870]
-        ptc_perm = gf.PermCount.from_ptc_count_object(ptc_raw)
-        assert ptc_perm.centreline_id == ptc_raw.centreline_id
-        assert ptc_perm.direction == ptc_raw.direction
-        # Python is beautiful - this does a deep compare!
-        # https://stackoverflow.com/questions/1911273/is-there-a-better-way-to-compare-dictionary-values/5635309#5635309
-        assert ptc_perm.data == ptc_raw.data
 
-        # Check AADT retrieval.
-        aadt = ptc_perm.get_aadt()
-        assert np.array_equal(ptc_perm.data['AADT'].index.values,
-                              aadt['Year'].values)
-        assert np.array_equal(ptc_perm.data['AADT']['AADT'].values,
-                              aadt['AADT'].values)
+class TestGrowthFactorBase:
+    """Test growth factor base class."""
 
-        # Check fitter.
-        fit = sm.OLS(np.log(aadt['AADT'].values / aadt['AADT'].values[0]),
-                     aadt['Year'].values - aadt['Year'].values[0]).fit()
-        ptc_perm.fit_growth()
-        assert ptc_perm._fit_type == 'Exponential'
-        assert np.isclose(ptc_perm.growth_factor, np.exp(fit.params[0]))
+    def setup(self):
+        self.gfb = gf.GrowthFactorBase()
 
-        # PTC -890 only has one year.
-        ptc_raw = rdr.ptcs[-890]
-        ptc_perm = gf.PermCount.from_ptc_count_object(ptc_raw)
+    def test_get_aadt(self, ptc_oneyear, ptc_multiyear):
+        for ptc in (ptc_oneyear, ptc_multiyear):
+            aadt = self.gfb.get_aadt(ptc)
+            assert list(np.sort(aadt.columns)) == ['AADT', 'Year']
+            assert aadt['Year'].dtype == np.dtype('float64')
+            assert np.array_equal(ptc.data['AADT'].index.values,
+                                  aadt['Year'].values)
+            assert np.array_equal(ptc.data['AADT']['AADT'].values,
+                                  aadt['AADT'].values)
 
-        # Check WADT retrieval.
-        wadt = ptc_perm.get_wadt()
-        cdata_week = pd.DataFrame(
-            {'Week': ptc_raw.data['Daily Count']['Date'].dt.week})
-        avail_week = (cdata_week.loc[cdata_week['Week'] < 53, :]
-                      .groupby('Week')['Week'].count())
-        # Check that all weeks with 7 days are in wadt.
-        assert np.array_equal(avail_week[avail_week == 7].index.values,
-                              wadt['Week'].unique().astype(int))
-        # Check WADT values.
-        wadt_jun14 = (ptc_raw.data['Daily Count']
+    def test_get_wadt_py(self, ptc_oneyear, ptc_multiyear):
+        # For single year PTC, confirm WADT values for individual weeks.
+        wadt_oy = self.gfb.get_wadt_py(ptc_oneyear)
+        wadt_jun14 = (ptc_oneyear.data['Daily Count']
                       .loc[(2010, 165):(2010, 171), 'Daily Count'].mean())
-        wadt_nov29 = (ptc_raw.data['Daily Count']
+        wadt_nov29 = (ptc_oneyear.data['Daily Count']
                       .loc[(2010, 333):(2010, 339), 'Daily Count'].mean())
         assert np.isclose(
-            (wadt.loc[wadt['Start of Week'] == '2010-06-14', 'WADT']
+            (wadt_oy.loc[wadt_oy['Start of Week'] == '2010-06-14', 'WADT']
              .values[0]), wadt_jun14)
         assert np.isclose(
-            (wadt.loc[wadt['Start of Week'] == '2010-11-29', 'WADT']
+            (wadt_oy.loc[wadt_oy['Start of Week'] == '2010-11-29', 'WADT']
              .values[0]), wadt_nov29)
 
-        # Check fit values.
-        fit = sm.OLS(wadt['WADT'].values,
-                     sm.add_constant(wadt['Week'].values)).fit()
-        ptc_perm.fit_growth()
-        assert ptc_perm._fit_type == 'Linear'
-        assert np.isclose(ptc_perm.growth_factor,
-                          1. + (fit.params[1] * 52. /
-                                ptc_raw.data['AADT'].iat[0, 0]))
+        # For multiyear PTC, confirm we can reproduce data frame.
+        wadt_my = self.gfb.get_wadt_py(ptc_multiyear)
 
-    def test_get_growth_factors(self):
-        # Test that using gf.get_growth_factors actually cycles through all
-        # permanent stations to calculate growth factors.
-        rdr = reader.Reader(SAMPLE_ZIP)
-        rdr.read()
+        ptc_multiyear_dc = ptc_multiyear.data['Daily Count'].loc[
+            ptc_multiyear.perm_years, :].copy()
+        ptc_multiyear_dc['Week'] = (
+            ptc_multiyear_dc['Date'] -
+            (ptc_multiyear_dc['Date'].dt.dayofweek *
+             np.timedelta64(1, 'D'))).dt.week
 
-        gf.get_growth_factors(rdr)
-        for item in rdr.ptcs.values():
-            assert isinstance(item, gf.PermCount)
-            assert item.growth_factor is not None
+        wadt_ref = (ptc_multiyear_dc.loc[ptc_multiyear_dc['Week'] < 53, :]
+                    .groupby(['Year', 'Week']).agg(['mean', 'count']))
+        wadt_ref.columns = ('WADT', 'N_days')
+        wadt_ref = wadt_ref.loc[wadt_ref['N_days'] == 7, :].reset_index()
+
+        wadt_ref['Week'] = (wadt_ref['Week'].astype(float) +
+                            52. * (wadt_ref['Year'] - wadt_ref['Year'].min()))
+
+        # Check that all weeks with 7 days are in wadt.
+        assert np.array_equal(wadt_ref['Week'], wadt_my['Week'])
+        assert np.array_equal(wadt_ref['WADT'], wadt_my['WADT'])

--- a/traffic_prophet/countmatch/tests/test_permcount.py
+++ b/traffic_prophet/countmatch/tests/test_permcount.py
@@ -26,6 +26,10 @@ class TestPermCount:
         assert ptc.is_permanent
         assert ptc.perm_years == [2010, 2012]
 
+        with pytest.raises(AttributeError) as excinfo:
+            ptc.growth_factor
+        assert "PTC has not had its growth factor fit!" in str(excinfo.value)
+
         with pytest.raises(ValueError) as excinfo:
             ptc = pc.PermCount.from_count_object(
                 sample_counts.counts[-104870], [])
@@ -37,7 +41,7 @@ class TestPermCountProcessor:
     def test_setup(self, pcproc):
         assert isinstance(pcproc.dvc, dv.DerivedValsStandard)
         assert isinstance(pcproc.gfc, gf.GrowthFactorComposite)
-        # We passed a custom cfgcm with no excluded IDs.
+        # We passed a custom cfgcm with one excluded ID.
         assert pcproc.excluded_ids == [-446378, ]
 
     def test_partition(self, pcproc, sample_counts):

--- a/traffic_prophet/countmatch/tests/test_permcount.py
+++ b/traffic_prophet/countmatch/tests/test_permcount.py
@@ -1,0 +1,70 @@
+import numpy as np
+import pytest
+
+from .. import reader
+from .. import base
+from .. import permcount as pc
+from .. import derivedvals as dv
+from .. import growthfactor as gf
+
+from ...data import SAMPLE_ZIP
+
+
+@pytest.fixture(scope='module')
+def pcproc(cfgcm_test):
+    dvc = dv.DerivedVals('Standard')
+    gfc = gf.GrowthFactor('Composite')
+    return pc.PermCountProcessor(dvc, gfc, cfg=cfgcm_test)
+
+
+class TestPermCount:
+
+    def test_permcount(self, sample_counts):
+        ptc = pc.PermCount.from_count_object(sample_counts.counts[-104870],
+                                             [2010, 2012])
+        assert isinstance(ptc, pc.PermCount)
+        assert ptc.is_permanent
+        assert ptc.perm_years == [2010, 2012]
+
+        with pytest.raises(ValueError) as excinfo:
+            ptc = pc.PermCount.from_count_object(
+                sample_counts.counts[-104870], [])
+        assert "cannot have empty perm_years" in str(excinfo.value)
+
+
+class TestPermCountProcessor:
+
+    def test_setup(self, pcproc):
+        assert isinstance(pcproc.dvc, dv.DerivedValsStandard)
+        assert isinstance(pcproc.gfc, gf.GrowthFactorComposite)
+        # We passed a custom cfgcm with no excluded IDs.
+        assert pcproc.excluded_ids == [-446378, ]
+
+    def test_partition(self, pcproc, sample_counts):
+        ptc_oy_permyears = pcproc.partition_years(sample_counts.counts[-890])
+        assert np.array_equal(ptc_oy_permyears, np.array([2010], dtype=int))
+        ptc_my_permyears = pcproc.partition_years(
+            sample_counts.counts[-104870])
+        assert np.array_equal(ptc_my_permyears,
+                              np.array([2010, 2012], dtype=int))
+
+    def test_ptcs_sttcs(self, pcproc, cfgcm_test):
+        # Can't use the fixture since this test will alter tcs.
+        tcs = reader.read(SAMPLE_ZIP, cfg=cfgcm_test)
+        pcproc.get_ptcs_sttcs(tcs)
+
+        assert sorted(tcs.ptcs.keys()) == [-104870, -890]
+        assert (sorted(tcs.sttcs.keys()) ==
+                [-446378, -1978, -680, -487, -427, -410,
+                 -252, -241, -170, 170, 104870])
+
+        for ptc in tcs.ptcs.values():
+            assert isinstance(ptc, pc.PermCount)
+            assert (sorted(list(ptc.adts.keys())) ==
+                    ['AADT', 'MADT'])
+            assert (sorted(list(ptc.ratios.keys())) ==
+                    ['D_ijd', 'DoM_ijd', 'N_avail_days'])
+            assert abs(ptc.growth_factor) > 0.
+
+        for sttc in tcs.sttcs.values():
+            assert isinstance(sttc, base.Count)

--- a/traffic_prophet/countmatch/tests/test_reader.py
+++ b/traffic_prophet/countmatch/tests/test_reader.py
@@ -21,7 +21,7 @@ def counts(rdr):
 class TestRawAnnualCount:
     """Test preprocessing routines in RawAnnualCount."""
 
-    def test_from_raw_data(self, rdr, mister_x):
+    def test_from_raw_data(self, rdr):
         zr = rdr.get_zipreader(SAMPLE_ZIP['2010'])
         data = rdr.preprocess_count_data(list(zr)[7])
 

--- a/traffic_prophet/countmatch/tests/test_reader.py
+++ b/traffic_prophet/countmatch/tests/test_reader.py
@@ -120,8 +120,8 @@ class TestReaderZip:
 
     def test_preprocess_count_data(self, rdr, counts):
         ref = counts[7]
-        rd = ref.copy()
         # Do a deep copy because preprocess_count_data alters its arguments.
+        rd = ref.copy()
         rd['data'] = rd['data'].copy()
 
         rd = rdr.preprocess_count_data(rd)

--- a/traffic_prophet/countmatch/tests/test_reader.py
+++ b/traffic_prophet/countmatch/tests/test_reader.py
@@ -3,6 +3,7 @@ import numpy as np
 import pandas as pd
 
 from ...data import SAMPLE_ZIP
+from .. import base
 from .. import reader
 
 
@@ -242,7 +243,7 @@ class TestReaderZip:
         assert (sorted(rdr.counts.keys()) ==
                 [-446378, -104870, -1978, -890, -680, -487, -427, -410,
                  -252, -241, -170, 170, 104870])
-        assert isinstance(rdr.counts[-241], reader.Count)
+        assert isinstance(rdr.counts[-241], base.Count)
 
         # Check that all available years have been read in.
         included_years = []


### PR DESCRIPTION
Significant refactoring of CountMatch and its test suite.  Changes:
- Separate traffic count categorization from reading raw data.  `reader.read` now returns a set of counts, which are parsed into PTCs and STTCs using `permcount.PermCountProcessor`.
- Derived value and growth factor calculation now occur within `permcount.PermCountProcessor`, but are governed by separate `derivedval` and `growthfactor` modules.  This allows alternative growth factor calculators, or more derived value calculators with more sophisticated imputers, to be slotted into `PermCountProcessor` in the future.
- Code for calculating derived values, like AADT and `D_ijd`, has been further modularized.  There is now a separate class method for calculating each derived value (except for `D_ijd`, `DoM_ijd`, and other values that use the day-of-month ADT, but the class structure makes it easy for us to split these up if needed).  Each derived value calculator class defines or inherits these methods, making it possible to build complex calculators from simple ones.
- There's now a metaclass registry-based class instance initializer for both derived value and growth factor calculators, inspired by the Baseband package's [VDIF header module](https://github.com/mhvk/baseband/blob/master/baseband/vdif/header.py).

Resolves #32.

Aside from the usual code read-through for this PR, we need to:
- Check if there are variants of all old tests - no point in dropping well-designed and useful ones!
- Compare whether the PTC and STTC dictionaries produced by this version of CountMatch are identical to `rdr.sttcs` and `rdr.ptcs` produced by older versions of CountMatch.  The refactoring shouldn't have changed any final outputs.