### PR TITLE
Simple PTC ratios imputer

### DIFF
--- a/traffic_prophet/countmatch/derivedvals.py
+++ b/traffic_prophet/countmatch/derivedvals.py
@@ -2,6 +2,8 @@
 
 import numpy as np
 import pandas as pd
+from sklearn.experimental import enable_iterative_imputer
+from sklearn import impute as skimp
 
 
 DV_REGISTRY = {}
@@ -194,8 +196,9 @@ class DerivedValsStandard(DerivedValsBase):
 
     _dv_type = 'Standard'
 
-    def __init__(self, impute_ratios=False):
+    def __init__(self, impute_ratios=False, **kwargs):
         self._impute_ratios = impute_ratios
+        self._imputer_args = kwargs
 
     def get_derived_vals(self, ptc):
         """Get derived values, including ADTs and ratios between them.
@@ -221,5 +224,26 @@ class DerivedValsStandard(DerivedValsBase):
         if self._impute_ratios:
             self.impute_ratios(ptc)
 
+    @staticmethod
+    def fill_nans(df, imp):
+        """Fill NaN values in an array with imputed ones.
+
+        Parameters
+        ----------
+        df : pandas.DataFrame
+            Original data, with NaNs.
+        imp : numpy.ndarray
+            Data array with imputed values.
+
+        """
+        for i, j in zip(*np.where(df.isnull())):
+            df.iloc[i, j] = imp[i, j]
+
     def impute_ratios(self, ptc):
-        raise NotImplementedError
+        imp = skimp.IterativeImputer(**self._imputer_args)
+
+        dom_ijd_imputed = imp.fit_transform(ptc.ratios['DoM_ijd'])
+        d_ijd_imputed = imp.fit_transform(ptc.ratios['D_ijd'])
+
+        self.fill_nans(ptc.ratios['DoM_ijd'], dom_ijd_imputed)
+        self.fill_nans(ptc.ratios['D_ijd'], d_ijd_imputed)

--- a/traffic_prophet/countmatch/derivedvals.py
+++ b/traffic_prophet/countmatch/derivedvals.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 import pandas as pd
+# TO DO: remove this once the imputer is no longer experimental.
 from sklearn.experimental import enable_iterative_imputer
 from sklearn import impute as skimp
 
@@ -233,7 +234,7 @@ class DerivedValsStandard(DerivedValsBase):
         df : pandas.DataFrame
             Original data, with NaNs.
         imp : numpy.ndarray
-            Data array with imputed values.
+            Data array of imputed values.
 
         """
         for i, j in zip(*np.where(df.isnull())):

--- a/traffic_prophet/countmatch/tests/test_derivedvals.py
+++ b/traffic_prophet/countmatch/tests/test_derivedvals.py
@@ -176,16 +176,24 @@ class TestDerivedValsStandard:
         ptc = get_single_ptc(sample_counts, cfgcm_test, -104870)
         ptc_imp = get_single_ptc(sample_counts, cfgcm_test, -104870)
 
-        dvc_imp = dv.DerivedVals('Standard', impute_ratios=True, max_iter=10)
+        dvc_imp = dv.DerivedVals('Standard', impute_ratios=True, max_iter=100)
+        # Check that we can set imputer args (that are off by default).
+        assert not self.dvc._impute_ratios
+        assert dvc_imp._impute_ratios
+        assert dvc_imp._imputer_args['max_iter'] == 100
 
         self.dvc.get_derived_vals(ptc)
         dvc_imp.get_derived_vals(ptc_imp)
 
-        # Check that NaNs have been filled.
+        # Check that a specific NaN has been filled.
         assert np.isnan(ptc.ratios['DoM_ijd'].at[(2010, 5), 4])
         assert np.isnan(ptc.ratios['D_ijd'].at[(2010, 5), 4])
         assert not np.isnan(ptc_imp.ratios['DoM_ijd'].at[(2010, 5), 4])
         assert not np.isnan(ptc_imp.ratios['D_ijd'].at[(2010, 5), 4])
+
+        # Check that all NaNs are filled.
+        assert not np.any(ptc_imp.ratios['DoM_ijd'].isnull())
+        assert not np.any(ptc_imp.ratios['D_ijd'].isnull())
 
         # Check that non-NaN values are untouched.
         notnulls = ~np.isnan(ptc.ratios['DoM_ijd'].values)


### PR DESCRIPTION
Scaled down prototype of a PTC imputer.  Currently only works to plug holes in ratio derived values like MADT to day-of-month ADT ratio, but can serve as the basis for more sophisticated imputation experiments when we finally get around to it.

Resolves #33 (since the advanced stuff got moved to #38).